### PR TITLE
feat(puzzle): add pressure button interaction

### DIFF
--- a/Assets/Prefabs/Clone.prefab
+++ b/Assets/Prefabs/Clone.prefab
@@ -42,6 +42,7 @@ GameObject:
   - component: {fileID: 7133769528600657502}
   - component: {fileID: 1485530581581262821}
   - component: {fileID: 1778651046099077494}
+  - component: {fileID: 6105082151468812345}
   - component: {fileID: 2245391475217408481}
   m_Layer: 0
   m_Name: Clone
@@ -163,6 +164,33 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!50 &6105082151468812345
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4740635916072682834}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 1
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4
 --- !u!114 &2245391475217408481
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level_01_Tutorial.unity
+++ b/Assets/Scenes/Level_01_Tutorial.unity
@@ -160,7 +160,7 @@ Transform:
   m_GameObject: {fileID: 29042378}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -4.5, y: 1, z: 0}
+  m_LocalPosition: {x: -4.5, y: -2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -394,6 +394,154 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &217809865
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 217809869}
+  - component: {fileID: 217809868}
+  - component: {fileID: 217809867}
+  - component: {fileID: 217809866}
+  m_Layer: 0
+  m_Name: PuzzleButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &217809866
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 217809865}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 40e424a345bb3a144ac4ba137a3bb402, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  targetRenderer: {fileID: 217809868}
+  inactiveColor: {r: 0.55, g: 0.2, b: 0.2, a: 1}
+  activeColor: {r: 0.35, g: 0.9, b: 0.45, a: 1}
+  reactToPlayer: 1
+  reactToClone: 1
+--- !u!61 &217809867
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 217809865}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!212 &217809868
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 217809865}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 0, b: 0.91008663, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &217809869
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 217809865}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2, y: -2.375, z: 0}
+  m_LocalScale: {x: 1, y: 0.25, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &260943786
 GameObject:
   m_ObjectHideFlags: 0
@@ -922,7 +1070,7 @@ Transform:
   m_GameObject: {fileID: 1210059138}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 2, z: 0}
+  m_LocalPosition: {x: -2, y: -2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1053,8 +1201,8 @@ Transform:
   m_GameObject: {fileID: 1571183263}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 10, y: 1, z: 1}
+  m_LocalPosition: {x: 0, y: -3, z: 0}
+  m_LocalScale: {x: 30, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -1173,3 +1321,4 @@ SceneRoots:
   - {fileID: 1210059145}
   - {fileID: 29042380}
   - {fileID: 260943792}
+  - {fileID: 217809869}

--- a/Assets/Scripts/Level.meta
+++ b/Assets/Scripts/Level.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4d75cb9f8bc9c0e47a2182f658efc61d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Level/PuzzleButton.cs
+++ b/Assets/Scripts/Level/PuzzleButton.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using ShadowClone.Clone;
+using ShadowClone.Gameplay;
+using UnityEngine;
+
+namespace ShadowClone.Level
+{
+    [RequireComponent(typeof(Collider2D))]
+    public class PuzzleButton : MonoBehaviour
+    {
+        [SerializeField] private SpriteRenderer targetRenderer;
+        [SerializeField] private Color inactiveColor = new Color(0.55f, 0.2f, 0.2f, 1f);
+        [SerializeField] private Color activeColor = new Color(0.35f, 0.9f, 0.45f, 1f);
+        [SerializeField] private bool reactToPlayer = true;
+        [SerializeField] private bool reactToClone = true;
+
+        private readonly HashSet<Collider2D> occupants = new HashSet<Collider2D>();
+        private Collider2D triggerCollider;
+
+        public event Action<bool> PressedStateChanged;
+
+        public bool IsPressed => occupants.Count > 0;
+
+        private void Awake()
+        {
+            triggerCollider = GetComponent<Collider2D>();
+            triggerCollider.isTrigger = true;
+            UpdateVisual();
+        }
+
+        private void OnValidate()
+        {
+            Collider2D localCollider = GetComponent<Collider2D>();
+            if (localCollider != null)
+            {
+                localCollider.isTrigger = true;
+            }
+        }
+
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            if (!IsValidActivator(other))
+            {
+                return;
+            }
+
+            bool wasPressed = IsPressed;
+            occupants.Add(other);
+
+            if (wasPressed != IsPressed)
+            {
+                HandlePressedStateChanged();
+            }
+        }
+
+        private void OnTriggerExit2D(Collider2D other)
+        {
+            if (!occupants.Remove(other))
+            {
+                return;
+            }
+
+            HandlePressedStateChanged();
+        }
+
+        public void ClearState()
+        {
+            if (occupants.Count == 0)
+            {
+                return;
+            }
+
+            occupants.Clear();
+            HandlePressedStateChanged();
+        }
+
+        private bool IsValidActivator(Collider2D other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (reactToPlayer && other.GetComponentInParent<PlayerController>() != null)
+            {
+                return true;
+            }
+
+            if (reactToClone && other.GetComponentInParent<CloneActor>() != null)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private void HandlePressedStateChanged()
+        {
+            UpdateVisual();
+            PressedStateChanged?.Invoke(IsPressed);
+        }
+
+        private void UpdateVisual()
+        {
+            if (targetRenderer != null)
+            {
+                targetRenderer.color = IsPressed ? activeColor : inactiveColor;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Level/PuzzleButton.cs.meta
+++ b/Assets/Scripts/Level/PuzzleButton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 40e424a345bb3a144ac4ba137a3bb402
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ The format can stay simple:
 - Initial Unity project scaffolding under `Assets/`, `Packages/`, and `ProjectSettings/`
 - First gameplay script pass for movement, reset flow, recording, replay, HUD feedback, and clone cleanup
 - Coding standards and Unity setup / smoke test documentation for issues `SC-02` through `SC-10`
+- Reusable `PuzzleButton` trigger script and initial smoke-test guidance for `SC-11`
 
 ### Changed
 

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -16,6 +16,7 @@ These rules cover the first implementation slice for SC-03 and are meant to keep
 - `Core/`: scene flow, camera framing, spawn points, room reset coordination.
 - `Gameplay/`: player movement, ground checks, and direct player-facing visuals.
 - `Clone/`: recording storage, recording input flow, clone spawn/replay, clone cleanup.
+- `Level/`: puzzle objects such as buttons, doors, hazards, and goals.
 - `UI/`: simple HUD and player-readable mechanic feedback.
 
 ## Practical Rules
@@ -36,6 +37,7 @@ These rules cover the first implementation slice for SC-03 and are meant to keep
 - `CloneActor` owns movement along recorded frames.
 - `CloneMechanicController` owns player inputs for record and replay.
 - `RoomResetManager` owns room restart coordination and spawn restoration.
+- `PuzzleButton` owns trigger overlap detection and pressed-state reporting.
 - `MechanicHudController` owns simple text feedback to the player.
 
 ## Guardrails

--- a/docs/SMOKE_TEST_CHECKLIST.md
+++ b/docs/SMOKE_TEST_CHECKLIST.md
@@ -21,6 +21,13 @@ Use this checklist after wiring the scripts in the Unity editor.
 - Only one replay clone exists at a time.
 - Reset removes the active clone and clears the last recording.
 
+## Puzzle Button
+
+- A `PuzzleButton` object can be placed in the tutorial room.
+- Walking the player onto the button changes it to its active state.
+- Stepping off the button returns it to its inactive state.
+- A replay clone can also activate the same button.
+
 ## Readability
 
 - HUD text changes for ready, recording, blocked, replay, and reset states.

--- a/docs/UNITY_SETUP_GUIDE.md
+++ b/docs/UNITY_SETUP_GUIDE.md
@@ -52,6 +52,16 @@ This repo now includes the first gameplay script pass for SC-02 through SC-10, b
 
 ## Smoke Tests
 
+### SC-11 Pressure Button
+
+- Create a square button object in `Level_01_Tutorial`.
+- Add a `BoxCollider2D` and enable `Is Trigger`.
+- Add `PuzzleButton`.
+- Assign the button's `SpriteRenderer` to `Target Renderer`.
+- Walk the player onto the button.
+- Confirm the button changes color while occupied and returns to its idle color after stepping off.
+- Trigger replay onto the button path and confirm the clone can also activate it.
+
 ### SC-04 Movement And Jump
 
 - Enter Play Mode in `Level_01_Tutorial`.


### PR DESCRIPTION
## Update: SC-11 Pressure Button Interaction

### What Changed

- added a reusable `PuzzleButton` gameplay script
- button now detects overlap from both the player and the replay clone
- button exposes pressed state for future puzzle-object hookups
- added simple active / inactive visual feedback through color change
- updated setup and smoke-test docs for the new button interaction

### Why It Matters

This is the first puzzle object tied to the clone mechanic. It moves the project beyond movement and replay alone and starts the interactive room logic needed for button-door puzzles.

### How It Was Checked

- placed a `PuzzleButton` object in `Level_01_Tutorial`
- confirmed the player activates the button on overlap
- confirmed the button returns to idle when the player steps off
- confirmed the replay clone can also activate the button
- fixed clone trigger participation by adding the needed `Rigidbody2D` setup to the clone prefab

### Follow-Up Work

- implement `SC-12` linked door behavior
- connect button pressed state to door open / close logic
- expand the tutorial room into a real button-door puzzle prototype
