### PR TITLE
feat(puzzle): add linked door system

### DIFF
--- a/Assets/Scenes/Level_01_Tutorial.unity
+++ b/Assets/Scenes/Level_01_Tutorial.unity
@@ -1202,7 +1202,156 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: -3, z: 0}
-  m_LocalScale: {x: 30, y: 1, z: 1}
+  m_LocalScale: {x: 100, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1696415607
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1696415611}
+  - component: {fileID: 1696415610}
+  - component: {fileID: 1696415609}
+  - component: {fileID: 1696415608}
+  m_Layer: 0
+  m_Name: Door
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1696415608
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1696415607}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2ea8db87acfc864b9ca5047769f3906, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  linkedButton: {fileID: 217809866}
+  blockingCollider: {fileID: 1696415609}
+  targetRenderer: {fileID: 1696415610}
+  closedColor: {r: 0.21698111, g: 0.21698111, b: 0.21698111, a: 1}
+  openColor: {r: 0.6603774, g: 0.6603774, b: 0.6603774, a: 0}
+  startOpen: 0
+--- !u!61 &1696415609
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1696415607}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!212 &1696415610
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1696415607}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 0.5377358, g: 0.5377358, b: 0.5377358, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1696415611
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1696415607}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 7, y: -1, z: 0}
+  m_LocalScale: {x: 1, y: 3, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -1322,3 +1471,4 @@ SceneRoots:
   - {fileID: 29042380}
   - {fileID: 260943792}
   - {fileID: 217809869}
+  - {fileID: 1696415611}

--- a/Assets/Scripts/Level/DoorController.cs
+++ b/Assets/Scripts/Level/DoorController.cs
@@ -1,0 +1,86 @@
+using UnityEngine;
+
+namespace ShadowClone.Level
+{
+    public class DoorController : MonoBehaviour
+    {
+        [SerializeField] private PuzzleButton linkedButton;
+        [SerializeField] private Collider2D blockingCollider;
+        [SerializeField] private SpriteRenderer targetRenderer;
+        [SerializeField] private Color closedColor = new Color(0.9f, 0.25f, 0.25f, 1f);
+        [SerializeField] private Color openColor = new Color(0.35f, 0.95f, 0.55f, 0.35f);
+        [SerializeField] private bool startOpen;
+
+        public bool IsOpen { get; private set; }
+
+        private void Awake()
+        {
+            ApplyState(startOpen);
+        }
+
+        private void OnEnable()
+        {
+            if (linkedButton != null)
+            {
+                linkedButton.PressedStateChanged += HandleButtonPressedStateChanged;
+            }
+        }
+
+        private void Start()
+        {
+            if (linkedButton != null)
+            {
+                ApplyState(linkedButton.IsPressed);
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (linkedButton != null)
+            {
+                linkedButton.PressedStateChanged -= HandleButtonPressedStateChanged;
+            }
+        }
+
+        public void SetLinkedButton(PuzzleButton button)
+        {
+            if (linkedButton != null)
+            {
+                linkedButton.PressedStateChanged -= HandleButtonPressedStateChanged;
+            }
+
+            linkedButton = button;
+
+            if (isActiveAndEnabled && linkedButton != null)
+            {
+                linkedButton.PressedStateChanged += HandleButtonPressedStateChanged;
+                ApplyState(linkedButton.IsPressed);
+            }
+        }
+
+        public void ForceClosed()
+        {
+            ApplyState(false);
+        }
+
+        private void HandleButtonPressedStateChanged(bool isPressed)
+        {
+            ApplyState(isPressed);
+        }
+
+        private void ApplyState(bool shouldOpen)
+        {
+            IsOpen = shouldOpen;
+
+            if (blockingCollider != null)
+            {
+                blockingCollider.enabled = !IsOpen;
+            }
+
+            if (targetRenderer != null)
+            {
+                targetRenderer.color = IsOpen ? openColor : closedColor;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Level/DoorController.cs.meta
+++ b/Assets/Scripts/Level/DoorController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d2ea8db87acfc864b9ca5047769f3906
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ The format can stay simple:
 - First gameplay script pass for movement, reset flow, recording, replay, HUD feedback, and clone cleanup
 - Coding standards and Unity setup / smoke test documentation for issues `SC-02` through `SC-10`
 - Reusable `PuzzleButton` trigger script and initial smoke-test guidance for `SC-11`
+- Reusable `DoorController` linked-door script and smoke-test guidance for `SC-12`
 
 ### Changed
 

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -38,6 +38,7 @@ These rules cover the first implementation slice for SC-03 and are meant to keep
 - `CloneMechanicController` owns player inputs for record and replay.
 - `RoomResetManager` owns room restart coordination and spawn restoration.
 - `PuzzleButton` owns trigger overlap detection and pressed-state reporting.
+- `DoorController` owns door open/close visuals and blocking collision.
 - `MechanicHudController` owns simple text feedback to the player.
 
 ## Guardrails

--- a/docs/SMOKE_TEST_CHECKLIST.md
+++ b/docs/SMOKE_TEST_CHECKLIST.md
@@ -28,6 +28,13 @@ Use this checklist after wiring the scripts in the Unity editor.
 - Stepping off the button returns it to its inactive state.
 - A replay clone can also activate the same button.
 
+## Linked Door
+
+- A `DoorController` object can be linked to a `PuzzleButton`.
+- The door is visually closed and physically blocking when the button is idle.
+- The door becomes visually open and non-blocking while the button is pressed.
+- The replay clone can hold the button while the player passes through the door.
+
 ## Readability
 
 - HUD text changes for ready, recording, blocked, replay, and reset states.

--- a/docs/UNITY_SETUP_GUIDE.md
+++ b/docs/UNITY_SETUP_GUIDE.md
@@ -62,6 +62,19 @@ This repo now includes the first gameplay script pass for SC-02 through SC-10, b
 - Confirm the button changes color while occupied and returns to its idle color after stepping off.
 - Trigger replay onto the button path and confirm the clone can also activate it.
 
+### SC-12 Linked Door
+
+- Create a tall square object named `Door` in `Level_01_Tutorial`.
+- Add a `BoxCollider2D`.
+- Add `DoorController`.
+- Assign the door's `BoxCollider2D` to `Blocking Collider`.
+- Assign the door's `SpriteRenderer` to `Target Renderer`.
+- Assign the scene's `PuzzleButton` to `Linked Button`.
+- Place the door so it blocks player movement while closed.
+- Walk onto the button and confirm the door changes to its open color and no longer blocks movement.
+- Step off the button and confirm the door returns to its closed color and blocks movement again.
+- Record a path that leaves the clone standing on the button, then move the player through the open doorway.
+
 ### SC-04 Movement And Jump
 
 - Enter Play Mode in `Level_01_Tutorial`.


### PR DESCRIPTION
## Update: SC-12 Linked Door System

### What Changed

- added a reusable `DoorController` script
- linked door state directly to `PuzzleButton` pressed state
- door now updates both:
  - visual state through open / closed color changes
  - gameplay state through collider enable / disable
- updated docs and smoke-test guidance for the linked button-door setup
- wired the tutorial scene so the player and clone can use the button-door interaction

### Why It Matters

This is the first real puzzle pair in the project. It turns the clone mechanic into a solvable room interaction by requiring the button and door to work together.

### How It Was Checked

- placed a `Door` object in `Level_01_Tutorial`
- linked the door to the existing `PuzzleButton`
- confirmed the door is closed and blocking when the button is idle
- confirmed the door opens visually and stops blocking when the button is pressed
- confirmed the door closes again when the button is released
- confirmed the replay clone can hold the button while the player moves through the doorway

### Follow-Up Work

- implement `SC-13` hazard death and automatic room reset
- reset puzzle objects cleanly during more complex room failure states
- continue shaping the tutorial room into a stronger first puzzle
