### PR TITLE
feat(level): add hazard reset flow

### DIFF
--- a/Assets/Scenes/Level_01_Tutorial.unity
+++ b/Assets/Scenes/Level_01_Tutorial.unity
@@ -591,6 +591,10 @@ MonoBehaviour:
   playerController: {fileID: 1210059141}
   spawnPoint: {fileID: 29042379}
   cloneMechanicController: {fileID: 260943789}
+  resettableButtons:
+  - {fileID: 217809866}
+  resettableDoors:
+  - {fileID: 1696415608}
   resetKey: 9
   alternateResetKey: 8
 --- !u!114 &260943789
@@ -688,6 +692,151 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1210059145}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &924532919
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 924532923}
+  - component: {fileID: 924532922}
+  - component: {fileID: 924532921}
+  - component: {fileID: 924532920}
+  m_Layer: 0
+  m_Name: Hazard
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &924532920
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 924532919}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: adda0656eb60cd64b91f6d0e00216b88, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  roomResetManager: {fileID: 260943788}
+  resetReason: Hazard hit
+--- !u!61 &924532921
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 924532919}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!212 &924532922
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 924532919}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 0.5613208, b: 0.5613208, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &924532923
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 924532919}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 9.76, y: -2.375, z: 0}
+  m_LocalScale: {x: 2, y: 0.25, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &935077802
 GameObject:
@@ -1242,7 +1391,7 @@ MonoBehaviour:
   blockingCollider: {fileID: 1696415609}
   targetRenderer: {fileID: 1696415610}
   closedColor: {r: 0.21698111, g: 0.21698111, b: 0.21698111, a: 1}
-  openColor: {r: 0.6603774, g: 0.6603774, b: 0.6603774, a: 0}
+  openColor: {r: 0.49056602, g: 0.49056602, b: 0.49056602, a: 0.80784315}
   startOpen: 0
 --- !u!61 &1696415609
 BoxCollider2D:
@@ -1472,3 +1621,4 @@ SceneRoots:
   - {fileID: 260943792}
   - {fileID: 217809869}
   - {fileID: 1696415611}
+  - {fileID: 924532923}

--- a/Assets/Scripts/Core/RoomResetManager.cs
+++ b/Assets/Scripts/Core/RoomResetManager.cs
@@ -1,5 +1,6 @@
 using ShadowClone.Clone;
 using ShadowClone.Gameplay;
+using ShadowClone.Level;
 using UnityEngine;
 
 namespace ShadowClone.Core
@@ -9,6 +10,8 @@ namespace ShadowClone.Core
         [SerializeField] private PlayerController playerController;
         [SerializeField] private SpawnPoint spawnPoint;
         [SerializeField] private CloneMechanicController cloneMechanicController;
+        [SerializeField] private PuzzleButton[] resettableButtons;
+        [SerializeField] private DoorController[] resettableDoors;
         [SerializeField] private KeyCode resetKey = KeyCode.Tab;
         [SerializeField] private KeyCode alternateResetKey = KeyCode.Backspace;
 
@@ -35,6 +38,28 @@ namespace ShadowClone.Core
             if (cloneMechanicController != null)
             {
                 cloneMechanicController.ResetMechanicState(reason);
+            }
+
+            if (resettableButtons != null)
+            {
+                for (int i = 0; i < resettableButtons.Length; i++)
+                {
+                    if (resettableButtons[i] != null)
+                    {
+                        resettableButtons[i].ClearState();
+                    }
+                }
+            }
+
+            if (resettableDoors != null)
+            {
+                for (int i = 0; i < resettableDoors.Length; i++)
+                {
+                    if (resettableDoors[i] != null)
+                    {
+                        resettableDoors[i].ForceClosed();
+                    }
+                }
             }
 
             if (playerController != null && spawnPoint != null)

--- a/Assets/Scripts/Level/Hazard.cs
+++ b/Assets/Scripts/Level/Hazard.cs
@@ -1,0 +1,45 @@
+using ShadowClone.Core;
+using ShadowClone.Gameplay;
+using UnityEngine;
+
+namespace ShadowClone.Level
+{
+    [RequireComponent(typeof(Collider2D))]
+    public class Hazard : MonoBehaviour
+    {
+        [SerializeField] private RoomResetManager roomResetManager;
+        [SerializeField] private string resetReason = "Hazard hit";
+
+        private Collider2D triggerCollider;
+
+        private void Awake()
+        {
+            triggerCollider = GetComponent<Collider2D>();
+            triggerCollider.isTrigger = true;
+        }
+
+        private void OnValidate()
+        {
+            Collider2D localCollider = GetComponent<Collider2D>();
+            if (localCollider != null)
+            {
+                localCollider.isTrigger = true;
+            }
+        }
+
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            if (roomResetManager == null)
+            {
+                return;
+            }
+
+            if (other.GetComponentInParent<PlayerController>() == null)
+            {
+                return;
+            }
+
+            roomResetManager.RequestReset(resetReason);
+        }
+    }
+}

--- a/Assets/Scripts/Level/Hazard.cs.meta
+++ b/Assets/Scripts/Level/Hazard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: adda0656eb60cd64b91f6d0e00216b88
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ The format can stay simple:
 - Coding standards and Unity setup / smoke test documentation for issues `SC-02` through `SC-10`
 - Reusable `PuzzleButton` trigger script and initial smoke-test guidance for `SC-11`
 - Reusable `DoorController` linked-door script and smoke-test guidance for `SC-12`
+- Reusable `Hazard` trigger script and expanded room reset support for `SC-13`
 
 ### Changed
 

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -39,6 +39,7 @@ These rules cover the first implementation slice for SC-03 and are meant to keep
 - `RoomResetManager` owns room restart coordination and spawn restoration.
 - `PuzzleButton` owns trigger overlap detection and pressed-state reporting.
 - `DoorController` owns door open/close visuals and blocking collision.
+- `Hazard` owns lethal trigger detection and forwards resets to `RoomResetManager`.
 - `MechanicHudController` owns simple text feedback to the player.
 
 ## Guardrails

--- a/docs/SMOKE_TEST_CHECKLIST.md
+++ b/docs/SMOKE_TEST_CHECKLIST.md
@@ -35,6 +35,14 @@ Use this checklist after wiring the scripts in the Unity editor.
 - The door becomes visually open and non-blocking while the button is pressed.
 - The replay clone can hold the button while the player passes through the door.
 
+## Hazard Reset
+
+- A `Hazard` object can be placed in the tutorial room.
+- Touching the hazard resets the room every time.
+- Hazard reset returns the player to the spawn point.
+- Hazard reset clears the active clone and recorded mechanic state.
+- Hazard reset restores linked buttons and doors to their default closed / idle state.
+
 ## Readability
 
 - HUD text changes for ready, recording, blocked, replay, and reset states.

--- a/docs/UNITY_SETUP_GUIDE.md
+++ b/docs/UNITY_SETUP_GUIDE.md
@@ -75,6 +75,20 @@ This repo now includes the first gameplay script pass for SC-02 through SC-10, b
 - Step off the button and confirm the door returns to its closed color and blocks movement again.
 - Record a path that leaves the clone standing on the button, then move the player through the open doorway.
 
+### SC-13 Hazard Death And Reset
+
+- Create a square or rectangle object named `Hazard` in `Level_01_Tutorial`.
+- Add a `BoxCollider2D` and enable `Is Trigger`.
+- Add `Hazard`.
+- Assign the scene's `RoomResetManager` to the hazard.
+- On `RoomSystems > RoomResetManager`, add the scene's `PuzzleButton` to `Resettable Buttons`.
+- On `RoomSystems > RoomResetManager`, add the scene's `Door` to `Resettable Doors`.
+- Place the hazard so the player can intentionally touch it during play.
+- Run into the hazard and confirm the player returns to the spawn point.
+- Confirm the active clone is cleared.
+- Confirm the button returns to idle and the door returns to closed after the reset.
+- Repeat multiple times to confirm the reset is consistent.
+
 ### SC-04 Movement And Jump
 
 - Enter Play Mode in `Level_01_Tutorial`.


### PR DESCRIPTION
## Update: SC-13 Hazard Death And Automatic Room Reset

### What Changed

- added a reusable `Hazard` trigger script
- hazard now detects player contact and requests a room reset
- expanded `RoomResetManager` so reset can also restore:
  - linked buttons
  - linked doors
  - clone / recording state
- updated docs and smoke-test guidance for hazard-driven failure states
- wired the tutorial scene so hazard contact restores the room cleanly

### Why It Matters

This adds the first real fail state to the project. The prototype now supports fast retry after mistakes, which is essential for readable puzzle-platformer iteration.

### How It Was Checked

- placed a `Hazard` object in `Level_01_Tutorial`
- confirmed hazard contact resets the player to spawn
- confirmed hazard reset clears the active clone
- confirmed hazard reset restores the button to idle
- confirmed hazard reset restores the door to closed / blocking
- repeated the sequence multiple times to verify reset consistency

### Follow-Up Work

- implement `SC-14` goal zone and level completion trigger
- continue shaping the tutorial room into a full playable puzzle loop
- keep validating that resets remain stable as more room objects are added
