### PR TITLE
feat(level): add goal zone completion trigger

### DIFF
--- a/Assets/Scripts/Level/GoalZone.cs
+++ b/Assets/Scripts/Level/GoalZone.cs
@@ -1,0 +1,59 @@
+using ShadowClone.Gameplay;
+using ShadowClone.UI;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace ShadowClone.Level
+{
+    [RequireComponent(typeof(Collider2D))]
+    public class GoalZone : MonoBehaviour
+    {
+        [SerializeField] private PlayerController playerController;
+        [SerializeField] private MechanicHudController mechanicHudController;
+        [SerializeField] private string completionMessage = "Level complete!";
+        [SerializeField] private bool loadNextSceneOnComplete;
+        [SerializeField] private string nextSceneName;
+
+        private Collider2D triggerCollider;
+        private bool isCompleted;
+
+        public bool IsCompleted => isCompleted;
+
+        private void Awake()
+        {
+            triggerCollider = GetComponent<Collider2D>();
+            triggerCollider.isTrigger = true;
+        }
+
+        private void OnValidate()
+        {
+            Collider2D localCollider = GetComponent<Collider2D>();
+            if (localCollider != null)
+            {
+                localCollider.isTrigger = true;
+            }
+        }
+
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            if (isCompleted)
+            {
+                return;
+            }
+
+            if (other.GetComponentInParent<PlayerController>() == null)
+            {
+                return;
+            }
+
+            isCompleted = true;
+            playerController?.SetMovementLocked(true);
+            mechanicHudController?.ShowCompletion(completionMessage);
+
+            if (loadNextSceneOnComplete && !string.IsNullOrWhiteSpace(nextSceneName))
+            {
+                SceneManager.LoadScene(nextSceneName);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Level/GoalZone.cs.meta
+++ b/Assets/Scripts/Level/GoalZone.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f19934eab253f6f4ba32a856aed85153
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/MechanicHudController.cs
+++ b/Assets/Scripts/UI/MechanicHudController.cs
@@ -39,6 +39,11 @@ namespace ShadowClone.UI
             SetText($"{reason}. Room reset.");
         }
 
+        public void ShowCompletion(string message)
+        {
+            SetText(message);
+        }
+
         private void SetText(string value)
         {
             if (statusLabel != null)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ The format can stay simple:
 - Reusable `PuzzleButton` trigger script and initial smoke-test guidance for `SC-11`
 - Reusable `DoorController` linked-door script and smoke-test guidance for `SC-12`
 - Reusable `Hazard` trigger script and expanded room reset support for `SC-13`
+- Reusable `GoalZone` completion trigger and smoke-test guidance for `SC-14`
 
 ### Changed
 

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -40,6 +40,7 @@ These rules cover the first implementation slice for SC-03 and are meant to keep
 - `PuzzleButton` owns trigger overlap detection and pressed-state reporting.
 - `DoorController` owns door open/close visuals and blocking collision.
 - `Hazard` owns lethal trigger detection and forwards resets to `RoomResetManager`.
+- `GoalZone` owns level-complete trigger detection and minimal completion handoff.
 - `MechanicHudController` owns simple text feedback to the player.
 
 ## Guardrails

--- a/docs/SMOKE_TEST_CHECKLIST.md
+++ b/docs/SMOKE_TEST_CHECKLIST.md
@@ -43,6 +43,13 @@ Use this checklist after wiring the scripts in the Unity editor.
 - Hazard reset clears the active clone and recorded mechanic state.
 - Hazard reset restores linked buttons and doors to their default closed / idle state.
 
+## Goal Zone
+
+- A `GoalZone` object can be placed in the tutorial room.
+- Reaching the goal with the player displays a stable completion message.
+- Player movement locks after completion.
+- Replay clones do not accidentally complete the room on their own.
+
 ## Readability
 
 - HUD text changes for ready, recording, blocked, replay, and reset states.

--- a/docs/UNITY_SETUP_GUIDE.md
+++ b/docs/UNITY_SETUP_GUIDE.md
@@ -89,6 +89,19 @@ This repo now includes the first gameplay script pass for SC-02 through SC-10, b
 - Confirm the button returns to idle and the door returns to closed after the reset.
 - Repeat multiple times to confirm the reset is consistent.
 
+### SC-14 Goal Zone And Completion
+
+- Create a square object named `GoalZone` in `Level_01_Tutorial`.
+- Add a `BoxCollider2D` and enable `Is Trigger`.
+- Add `GoalZone`.
+- Assign the scene's `Player` to `Player Controller`.
+- Assign `RoomSystems > MechanicHudController` to `Mechanic Hud Controller`.
+- Leave `Load Next Scene On Complete` disabled for now unless you want an immediate scene transition.
+- Place the goal after the door so the player reaches it only after solving the room.
+- Reach the goal with the player and confirm the HUD shows a completion message.
+- Confirm the player can no longer move after completion.
+- Confirm replay clones do not trigger completion by themselves.
+
 ### SC-04 Movement And Jump
 
 - Enter Play Mode in `Level_01_Tutorial`.


### PR DESCRIPTION
## Update: SC-14 Goal Zone And Completion Trigger

### What Changed

- added a reusable `GoalZone` script
- goal zone now detects player arrival and triggers a stable room-complete state
- added minimal HUD completion messaging through `MechanicHudController`
- locked player movement after completion so the result stays readable and intentional
- updated setup and smoke-test docs for goal-zone completion behavior

### Why It Matters

This gives the room a real win condition. The prototype now has a complete interaction loop: solve the puzzle, reach the goal, and receive clear completion feedback.

### How It Was Checked

- placed a `GoalZone` object in `Level_01_Tutorial`
- confirmed reaching the goal with the player displays a completion message
- confirmed the player can no longer move after completion
- confirmed the completion state remains stable after triggering
- confirmed the current setup focuses on player completion rather than clone-driven completion

### Follow-Up Work

- implement fuller scene progression and end-of-level flow in later game-flow issues
- continue refining the tutorial room into a stronger complete first level
- decide whether post-completion replay/record input should be hard-disabled in a later pass
