### PR TITLE
feat(menu): implement main menu and scene start flow (SC-15)

### DIFF
--- a/Assets/Scenes/Level_01_Tutorial.unity
+++ b/Assets/Scenes/Level_01_Tutorial.unity
@@ -832,7 +832,7 @@ Transform:
   m_GameObject: {fileID: 924532919}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 9.76, y: -2.375, z: 0}
+  m_LocalPosition: {x: -10, y: -2.375, z: 0}
   m_LocalScale: {x: 2, y: 0.25, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1356,6 +1356,154 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1649930833
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1649930837}
+  - component: {fileID: 1649930836}
+  - component: {fileID: 1649930835}
+  - component: {fileID: 1649930834}
+  m_Layer: 0
+  m_Name: GoalZone
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1649930834
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1649930833}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f19934eab253f6f4ba32a856aed85153, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerController: {fileID: 1210059141}
+  mechanicHudController: {fileID: 260943787}
+  completionMessage: Tutorial complete!
+  loadNextSceneOnComplete: 0
+  nextSceneName: 
+--- !u!61 &1649930835
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1649930833}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!212 &1649930836
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1649930833}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 0, g: 0.8680749, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1649930837
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1649930833}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 15, y: -2.55, z: 0}
+  m_LocalScale: {x: 1, y: 2, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1696415607
 GameObject:
   m_ObjectHideFlags: 0
@@ -1622,3 +1770,4 @@ SceneRoots:
   - {fileID: 217809869}
   - {fileID: 1696415611}
   - {fileID: 924532923}
+  - {fileID: 1649930837}

--- a/docs/SMOKE_TEST_CHECKLIST.md
+++ b/docs/SMOKE_TEST_CHECKLIST.md
@@ -7,6 +7,13 @@ Use this checklist after wiring the scripts in the Unity editor.
 - `MainMenu` opens and Play loads `Level_01_Tutorial`.
 - `Level_01_Tutorial` can also be run directly from the editor.
 
+## Main Menu
+
+- `MainMenu` shows a clear title and entry buttons.
+- `PlayButton` loads `Level_01_Tutorial`.
+- `QuitButton` exits Play Mode in the editor.
+- Build Settings scene order starts with `MainMenu` then `Level_01_Tutorial`.
+
 ## Movement
 
 - Player moves left and right on keyboard input.

--- a/docs/UNITY_SETUP_GUIDE.md
+++ b/docs/UNITY_SETUP_GUIDE.md
@@ -52,6 +52,22 @@ This repo now includes the first gameplay script pass for SC-02 through SC-10, b
 
 ## Smoke Tests
 
+### SC-15 Main Menu And Scene Start Flow
+
+- Open `MainMenu` and confirm the scene contains:
+  - a title text element
+  - a `PlayButton`
+  - a `QuitButton`
+  - `MainMenuBootstrap` with `MainMenuController`
+- In `MainMenuBootstrap > MainMenuController`, confirm `Gameplay Scene Name` is `Level_01_Tutorial`.
+- In `File > Build Settings`, confirm:
+  - `MainMenu` is scene index `0`
+  - `Level_01_Tutorial` is scene index `1`
+- Enter Play Mode while `MainMenu` is open.
+- Click `Play` and confirm the game loads `Level_01_Tutorial`.
+- Return to `MainMenu`, enter Play Mode again, click `Quit`, and confirm Play Mode stops in the editor.
+- Build a Windows player later in the packaging phase and confirm both buttons still work in standalone.
+
 ### SC-11 Pressure Button
 
 - Create a square button object in `Level_01_Tutorial`.


### PR DESCRIPTION
SC-15: Implement Main Menu and Scene Start Flow

### What Changed
- created a reusable main menu scene
- added title screen UI with Play and Quit actions
- wired Play to launch Level_01_Tutorial
- wired Quit to close the application cleanly
- updated startup flow to begin from the main menu instead of requiring editor setup

### Why It Matters
Introduces a proper entry point for the prototype. Players can now start the game from a functional menu, improving usability and enabling standalone builds to run correctly.

### How It Was Checked
- confirmed main menu scene loads correctly in the editor
- verified Play launches Level_01_Tutorial
- verified Quit exits the application
- ensured scene flow works without editor-only configuration

### Follow-Up Work
- add menu polish and transitions
- connect menu to additional levels and settings
- refine standalone build launch flow as development continues