### PR TITLE
feat(ui): add pause and completion flow

### DIFF
--- a/Assets/Scripts/Clone/CloneMechanicController.cs
+++ b/Assets/Scripts/Clone/CloneMechanicController.cs
@@ -13,9 +13,20 @@ namespace ShadowClone.Clone
 
         private void Start()
         {
-            if (mechanicHudController != null && recordingController != null)
+            mechanicHudController?.ConfigureForGameplayStatus();
+            mechanicHudController?.Clear();
+
+            if (recordingController != null)
             {
-                mechanicHudController.ShowReady(recordingController.MaxRecordingDuration);
+                recordingController.RecordingFinished += HandleRecordingFinished;
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (recordingController != null)
+            {
+                recordingController.RecordingFinished -= HandleRecordingFinished;
             }
         }
 
@@ -41,12 +52,7 @@ namespace ShadowClone.Clone
 
             if (recordingController.IsRecording)
             {
-                bool capturedClip = recordingController.StopRecording();
-                if (mechanicHudController != null)
-                {
-                    mechanicHudController.ShowRecordingFinished(capturedClip, recordingController.CurrentClip.Duration);
-                }
-
+                recordingController.StopRecording();
                 return;
             }
 
@@ -90,6 +96,17 @@ namespace ShadowClone.Clone
                     mechanicHudController.ShowBlocked("Clone prefab missing or clip invalid.");
                 }
             }
+        }
+
+        private void HandleRecordingFinished(RecordingClip clip)
+        {
+            if (mechanicHudController == null || clip == null)
+            {
+                return;
+            }
+
+            bool capturedClip = clip.FrameCount > 1;
+            mechanicHudController.ShowRecordingFinished(capturedClip, clip.Duration);
         }
 
         public void ResetMechanicState(string reason)

--- a/Assets/Scripts/Core/SceneRegistry.cs
+++ b/Assets/Scripts/Core/SceneRegistry.cs
@@ -1,5 +1,3 @@
-using UnityEngine;
-
 namespace ShadowClone.Core
 {
     public static class SceneRegistry
@@ -7,5 +5,34 @@ namespace ShadowClone.Core
         public const string MainMenu = "MainMenu";
         public const string Tutorial = "Level_01_Tutorial";
         public const string Prototype = "Gameplay_Prototype";
+
+        public static readonly string[] CampaignLevels =
+        {
+            Tutorial
+        };
+
+        public static bool TryGetNextCampaignScene(string currentSceneName, out string nextSceneName)
+        {
+            nextSceneName = null;
+
+            for (int i = 0; i < CampaignLevels.Length; i++)
+            {
+                if (CampaignLevels[i] != currentSceneName)
+                {
+                    continue;
+                }
+
+                int nextIndex = i + 1;
+                if (nextIndex >= CampaignLevels.Length)
+                {
+                    return false;
+                }
+
+                nextSceneName = CampaignLevels[nextIndex];
+                return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/Assets/Scripts/Level/GoalZone.cs
+++ b/Assets/Scripts/Level/GoalZone.cs
@@ -1,3 +1,4 @@
+using System;
 using ShadowClone.Gameplay;
 using ShadowClone.UI;
 using UnityEngine;
@@ -18,6 +19,7 @@ namespace ShadowClone.Level
         private bool isCompleted;
 
         public bool IsCompleted => isCompleted;
+        public event Action Completed;
 
         private void Awake()
         {
@@ -49,6 +51,7 @@ namespace ShadowClone.Level
             isCompleted = true;
             playerController?.SetMovementLocked(true);
             mechanicHudController?.ShowCompletion(completionMessage);
+            Completed?.Invoke();
 
             if (loadNextSceneOnComplete && !string.IsNullOrWhiteSpace(nextSceneName))
             {

--- a/Assets/Scripts/UI/GameplayUiBootstrap.cs
+++ b/Assets/Scripts/UI/GameplayUiBootstrap.cs
@@ -1,0 +1,347 @@
+using ShadowClone.Clone;
+using ShadowClone.Core;
+using ShadowClone.Gameplay;
+using ShadowClone.Level;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+
+namespace ShadowClone.UI
+{
+    public class GameplayUiBootstrap : MonoBehaviour
+    {
+        private const string BootstrapObjectName = "GameplayUiBootstrap";
+        private static GameplayUiBootstrap instance;
+
+        private RoomResetManager roomResetManager;
+        private CloneMechanicController cloneMechanicController;
+        private PlayerController playerController;
+        private GoalZone goalZone;
+
+        private Canvas overlayCanvas;
+        private Text controlsLabel;
+        private GameObject pausePanel;
+        private GameObject completionPanel;
+        private Text completionTitle;
+        private Text completionBody;
+        private Button nextLevelButton;
+
+        private bool isPaused;
+        private bool isCompleted;
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void BootstrapForGameplayScene()
+        {
+            if (instance != null)
+            {
+                return;
+            }
+
+            GameObject bootstrapObject = new GameObject(BootstrapObjectName);
+            bootstrapObject.AddComponent<GameplayUiBootstrap>();
+        }
+
+        private void Awake()
+        {
+            if (instance != null && instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+
+            BuildOverlay();
+            SceneManager.sceneLoaded += HandleSceneLoaded;
+            HandleSceneLoaded(SceneManager.GetActiveScene(), LoadSceneMode.Single);
+        }
+
+        private void Update()
+        {
+            if (Input.GetKeyDown(KeyCode.Escape) && !isCompleted)
+            {
+                SetPaused(!isPaused);
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (goalZone != null)
+            {
+                goalZone.Completed -= HandleLevelCompleted;
+            }
+
+            if (instance == this)
+            {
+                SceneManager.sceneLoaded -= HandleSceneLoaded;
+                instance = null;
+            }
+
+            Time.timeScale = 1f;
+        }
+
+        private void HandleSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            ReleaseGoalSubscription();
+
+            isPaused = false;
+            isCompleted = false;
+            Time.timeScale = 1f;
+
+            if (scene.name == SceneRegistry.MainMenu)
+            {
+                overlayCanvas.enabled = false;
+                return;
+            }
+
+            overlayCanvas.enabled = true;
+            EnsureEventSystem();
+            RebindSceneDependencies();
+            pausePanel.SetActive(false);
+            completionPanel.SetActive(false);
+            RefreshControlsPrompt();
+        }
+
+        private void EnsureEventSystem()
+        {
+            if (FindObjectOfType<EventSystem>() != null)
+            {
+                return;
+            }
+
+            GameObject eventSystemObject = new GameObject("EventSystem");
+            eventSystemObject.AddComponent<EventSystem>();
+            eventSystemObject.AddComponent<StandaloneInputModule>();
+        }
+
+        private void BuildOverlay()
+        {
+            overlayCanvas = CreateCanvas();
+            controlsLabel = CreateText("ControlsLabel", overlayCanvas.transform, 28, TextAnchor.UpperLeft);
+            RectTransform controlsRect = controlsLabel.rectTransform;
+            controlsRect.anchorMin = new Vector2(0f, 1f);
+            controlsRect.anchorMax = new Vector2(0f, 1f);
+            controlsRect.pivot = new Vector2(0f, 1f);
+            controlsRect.anchoredPosition = new Vector2(24f, -24f);
+            controlsRect.sizeDelta = new Vector2(900f, 120f);
+
+            pausePanel = CreatePanel("PausePanel", overlayCanvas.transform, new Color(0.05f, 0.08f, 0.12f, 0.92f));
+            pausePanel.SetActive(false);
+            CreateText("PauseTitle", pausePanel.transform, 42, TextAnchor.MiddleCenter, "Paused");
+            CreateText("PauseBody", pausePanel.transform, 24, TextAnchor.MiddleCenter,
+                "Esc to resume\nTab / Backspace resets the room");
+
+            CreateButton("ResumeButton", pausePanel.transform, "Resume", new Vector2(0f, -12f), ResumeGameplay);
+            CreateButton("RestartButton", pausePanel.transform, "Restart Room", new Vector2(0f, -72f), RestartRoom);
+            CreateButton("MainMenuButton", pausePanel.transform, "Return To Menu", new Vector2(0f, -132f), ReturnToMenu);
+
+            completionPanel = CreatePanel("CompletionPanel", overlayCanvas.transform, new Color(0.08f, 0.15f, 0.11f, 0.94f));
+            completionPanel.SetActive(false);
+            completionTitle = CreateText("CompletionTitle", completionPanel.transform, 40, TextAnchor.MiddleCenter, "Level Complete");
+            completionBody = CreateText("CompletionBody", completionPanel.transform, 24, TextAnchor.MiddleCenter,
+                "You solved the room.");
+
+            nextLevelButton = CreateButton("NextLevelButton", completionPanel.transform, "Next Level", new Vector2(0f, -12f), LoadNextLevel);
+            CreateButton("ReplayLevelButton", completionPanel.transform, "Replay Level", new Vector2(0f, -72f), RestartRoom);
+            CreateButton("CompletionMenuButton", completionPanel.transform, "Return To Menu", new Vector2(0f, -132f), ReturnToMenu);
+        }
+
+        private Canvas CreateCanvas()
+        {
+            GameObject canvasObject = new GameObject("GameplayUiOverlay");
+            canvasObject.transform.SetParent(transform, false);
+
+            Canvas canvas = canvasObject.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvas.sortingOrder = 20;
+
+            CanvasScaler scaler = canvasObject.AddComponent<CanvasScaler>();
+            scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            scaler.referenceResolution = new Vector2(1920f, 1080f);
+
+            canvasObject.AddComponent<GraphicRaycaster>();
+            return canvas;
+        }
+
+        private void RefreshControlsPrompt()
+        {
+            if (controlsLabel == null)
+            {
+                return;
+            }
+
+            controlsLabel.text = "Move with A / D or arrows. Jump with Space. Press R to record, E to replay, Tab to reset, and Esc to pause.";
+        }
+
+        private void SetPaused(bool paused)
+        {
+            isPaused = paused;
+            pausePanel.SetActive(paused);
+            ApplyInteractiveState(paused);
+        }
+
+        private void ApplyInteractiveState(bool locked)
+        {
+            Time.timeScale = locked ? 0f : 1f;
+
+            if (playerController != null && !isCompleted)
+            {
+                playerController.SetMovementLocked(locked);
+            }
+
+            if (cloneMechanicController != null)
+            {
+                cloneMechanicController.enabled = !locked;
+            }
+
+            if (roomResetManager != null)
+            {
+                roomResetManager.enabled = !locked;
+            }
+        }
+
+        private void ResumeGameplay()
+        {
+            SetPaused(false);
+        }
+
+        private void RestartRoom()
+        {
+            Time.timeScale = 1f;
+            SceneManager.LoadScene(SceneManager.GetActiveScene().name);
+        }
+
+        private void ReturnToMenu()
+        {
+            Time.timeScale = 1f;
+            SceneManager.LoadScene(SceneRegistry.MainMenu);
+        }
+
+        private void HandleLevelCompleted()
+        {
+            isCompleted = true;
+            isPaused = false;
+            pausePanel.SetActive(false);
+            ApplyInteractiveState(true);
+
+            bool hasNextLevel = SceneRegistry.TryGetNextCampaignScene(SceneManager.GetActiveScene().name, out string nextSceneName);
+            completionPanel.SetActive(true);
+
+            if (hasNextLevel)
+            {
+                completionTitle.text = "Level Complete";
+                completionBody.text = $"Room cleared.\nNext up: {nextSceneName}";
+                nextLevelButton.gameObject.SetActive(true);
+            }
+            else
+            {
+                completionTitle.text = "Prototype Complete";
+                completionBody.text = "You reached the end of the current Shadow Clone campaign slice.\nReturn to the menu or replay the room.";
+                nextLevelButton.gameObject.SetActive(false);
+            }
+        }
+
+        private void LoadNextLevel()
+        {
+            if (!SceneRegistry.TryGetNextCampaignScene(SceneManager.GetActiveScene().name, out string nextSceneName))
+            {
+                return;
+            }
+
+            Time.timeScale = 1f;
+            SceneManager.LoadScene(nextSceneName);
+        }
+
+        private GameObject CreatePanel(string name, Transform parent, Color panelColor)
+        {
+            GameObject panelObject = new GameObject(name);
+            panelObject.transform.SetParent(parent, false);
+
+            Image image = panelObject.AddComponent<Image>();
+            image.color = panelColor;
+
+            RectTransform rect = panelObject.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0.5f, 0.5f);
+            rect.anchorMax = new Vector2(0.5f, 0.5f);
+            rect.pivot = new Vector2(0.5f, 0.5f);
+            rect.sizeDelta = new Vector2(760f, 420f);
+
+            return panelObject;
+        }
+
+        private Text CreateText(string name, Transform parent, int fontSize, TextAnchor alignment, string content = "")
+        {
+            GameObject textObject = new GameObject(name);
+            textObject.transform.SetParent(parent, false);
+
+            Text text = textObject.AddComponent<Text>();
+            text.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+            text.fontSize = fontSize;
+            text.alignment = alignment;
+            text.color = Color.white;
+            text.text = content;
+
+            RectTransform rect = text.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0.5f, 1f);
+            rect.anchorMax = new Vector2(0.5f, 1f);
+            rect.pivot = new Vector2(0.5f, 1f);
+            rect.anchoredPosition = name.Contains("Title") ? new Vector2(0f, -40f) : new Vector2(0f, -108f);
+            rect.sizeDelta = new Vector2(640f, 110f);
+
+            return text;
+        }
+
+        private Button CreateButton(string name, Transform parent, string label, Vector2 anchoredPosition, UnityEngine.Events.UnityAction onClick)
+        {
+            GameObject buttonObject = new GameObject(name);
+            buttonObject.transform.SetParent(parent, false);
+
+            Image buttonImage = buttonObject.AddComponent<Image>();
+            buttonImage.color = new Color(0.2f, 0.35f, 0.45f, 1f);
+
+            Button button = buttonObject.AddComponent<Button>();
+            button.targetGraphic = buttonImage;
+            button.onClick.AddListener(onClick);
+
+            RectTransform rect = buttonObject.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0.5f, 0.5f);
+            rect.anchorMax = new Vector2(0.5f, 0.5f);
+            rect.pivot = new Vector2(0.5f, 0.5f);
+            rect.anchoredPosition = anchoredPosition;
+            rect.sizeDelta = new Vector2(260f, 44f);
+
+            Text buttonText = CreateText($"{name}Label", buttonObject.transform, 24, TextAnchor.MiddleCenter, label);
+            RectTransform textRect = buttonText.rectTransform;
+            textRect.anchorMin = Vector2.zero;
+            textRect.anchorMax = Vector2.one;
+            textRect.pivot = new Vector2(0.5f, 0.5f);
+            textRect.anchoredPosition = Vector2.zero;
+            textRect.sizeDelta = Vector2.zero;
+
+            return button;
+        }
+
+        private void RebindSceneDependencies()
+        {
+            roomResetManager = FindObjectOfType<RoomResetManager>();
+            cloneMechanicController = FindObjectOfType<CloneMechanicController>();
+            playerController = FindObjectOfType<PlayerController>();
+            goalZone = FindObjectOfType<GoalZone>();
+
+            if (goalZone != null)
+            {
+                goalZone.Completed += HandleLevelCompleted;
+            }
+        }
+
+        private void ReleaseGoalSubscription()
+        {
+            if (goalZone != null)
+            {
+                goalZone.Completed -= HandleLevelCompleted;
+                goalZone = null;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UI/GameplayUiBootstrap.cs.meta
+++ b/Assets/Scripts/UI/GameplayUiBootstrap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1bdff08eb56c4f42b4557db96f637eb2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/MechanicHudController.cs
+++ b/Assets/Scripts/UI/MechanicHudController.cs
@@ -9,19 +9,19 @@ namespace ShadowClone.UI
 
         public void ShowReady(float duration)
         {
-            SetText($"Ready. R = record ({duration:0.0}s), E = replay, Tab = reset");
+            SetText($"Ready to record. Max {duration:0.0}s.");
         }
 
         public void ShowRecordingStarted(float duration)
         {
-            SetText($"Recording... max {duration:0.0}s");
+            SetText($"Recording... {duration:0.0}s max");
         }
 
         public void ShowRecordingFinished(bool success, float duration)
         {
             SetText(success
-                ? $"Recording saved ({duration:0.0}s). Press E to replay."
-                : "Recording too short. Try another path.");
+                ? $"Recorded. Press E to replay. ({duration:0.0}s)"
+                : "Recording too short. Try again.");
         }
 
         public void ShowReplayStarted(float duration)
@@ -42,6 +42,29 @@ namespace ShadowClone.UI
         public void ShowCompletion(string message)
         {
             SetText(message);
+        }
+
+        public void Clear()
+        {
+            SetText(string.Empty);
+        }
+
+        public void ConfigureForGameplayStatus()
+        {
+            if (statusLabel == null)
+            {
+                return;
+            }
+
+            statusLabel.fontSize = 24f;
+            statusLabel.alignment = TextAlignmentOptions.TopRight;
+
+            RectTransform rect = statusLabel.rectTransform;
+            rect.anchorMin = new Vector2(1f, 1f);
+            rect.anchorMax = new Vector2(1f, 1f);
+            rect.pivot = new Vector2(1f, 1f);
+            rect.anchoredPosition = new Vector2(-24f, -24f);
+            rect.sizeDelta = new Vector2(600f, 120f);
         }
 
         private void SetText(string value)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ The format can stay simple:
 - Reusable `DoorController` linked-door script and smoke-test guidance for `SC-12`
 - Reusable `Hazard` trigger script and expanded room reset support for `SC-13`
 - Reusable `GoalZone` completion trigger and smoke-test guidance for `SC-14`
+- Runtime gameplay UI bootstrap for pause, restart, return-to-menu, and final completion flow for `SC-16` and `SC-17`
 
 ### Changed
 

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -18,6 +18,7 @@ These rules cover the first implementation slice for SC-03 and are meant to keep
 - `Clone/`: recording storage, recording input flow, clone spawn/replay, clone cleanup.
 - `Level/`: puzzle objects such as buttons, doors, hazards, and goals.
 - `UI/`: simple HUD and player-readable mechanic feedback.
+- `UI/GameplayUiBootstrap` owns runtime pause / completion overlays for gameplay scenes.
 
 ## Practical Rules
 
@@ -42,6 +43,7 @@ These rules cover the first implementation slice for SC-03 and are meant to keep
 - `Hazard` owns lethal trigger detection and forwards resets to `RoomResetManager`.
 - `GoalZone` owns level-complete trigger detection and minimal completion handoff.
 - `MechanicHudController` owns simple text feedback to the player.
+- `GameplayUiBootstrap` owns pause, restart, return-to-menu, and completion-screen wiring.
 
 ## Guardrails
 

--- a/docs/SMOKE_TEST_CHECKLIST.md
+++ b/docs/SMOKE_TEST_CHECKLIST.md
@@ -57,6 +57,21 @@ Use this checklist after wiring the scripts in the Unity editor.
 - Player movement locks after completion.
 - Replay clones do not accidentally complete the room on their own.
 
+## Pause And Restart
+
+- `Esc` opens a pause menu in gameplay scenes.
+- Pause blocks player movement and record / replay input.
+- `Resume` returns to live gameplay cleanly.
+- `Restart Room` reloads the current level.
+- `Return To Menu` loads `MainMenu`.
+
+## Completion Flow
+
+- Reaching the goal opens a clear completion overlay.
+- The current prototype can be replayed or exited back to the menu after completion.
+- Final completion state feels intentional rather than like a debug message.
+- When multiple campaign levels exist, completion can route to the next scene in order.
+
 ## Readability
 
 - HUD text changes for ready, recording, blocked, replay, and reset states.

--- a/docs/UNITY_SETUP_GUIDE.md
+++ b/docs/UNITY_SETUP_GUIDE.md
@@ -52,6 +52,33 @@ This repo now includes the first gameplay script pass for SC-02 through SC-10, b
 
 ## Smoke Tests
 
+### SC-16 Pause Menu, Restart, And HUD
+
+- Enter Play Mode in `Level_01_Tutorial`.
+- Confirm a gameplay overlay appears automatically in non-menu scenes.
+- Confirm the controls prompt is visible and includes move, jump, record, replay, reset, and pause keys.
+- Press `Esc` and confirm a pause menu appears with:
+  - `Resume`
+  - `Restart Room`
+  - `Return To Menu`
+- While paused, confirm the player cannot move and recording / replay input is blocked.
+- Click `Resume` and confirm gameplay continues.
+- Pause again, click `Restart Room`, and confirm the current level reloads cleanly.
+- Pause again, click `Return To Menu`, and confirm the game loads `MainMenu`.
+
+### SC-17 Level Complete And Final Completion Flow
+
+- Open `Level_01_Tutorial` and keep its `GoalZone` wired as before.
+- Enter Play Mode and solve the room.
+- Reach the goal and confirm a completion overlay appears.
+- Because the current campaign list contains only `Level_01_Tutorial`, confirm the overlay behaves as a final completion screen by showing:
+  - a completion title
+  - a replay button
+  - a return-to-menu button
+- Click `Replay Level` and confirm the room reloads.
+- Reach the goal again, click `Return To Menu`, and confirm the project returns to `MainMenu`.
+- When more gameplay scenes are added later, update `SceneRegistry.CampaignLevels` so the same overlay can expose `Next Level`.
+
 ### SC-15 Main Menu And Scene Start Flow
 
 - Open `MainMenu` and confirm the scene contains:


### PR DESCRIPTION
## Update: SC-16 And SC-17 Gameplay UI Flow

### What Changed

- added a runtime `GameplayUiBootstrap` for gameplay scenes
- added one clear tutorial controls prompt instead of overlapping startup text
- added a pause menu with:
  - resume
  - restart room
  - return to menu
- made the runtime gameplay UI persist and rebind correctly after scene reloads
- extended `GoalZone` with a completion event so UI flow can react cleanly
- added campaign scene-order helpers in `SceneRegistry`
- added a completion overlay that works as the prototype's final completion screen when no next level exists
- moved mechanic status text to a separate gameplay status area
- updated recording status so it changes from `Recording...` to `Recorded` both on manual stop and when the 3-second timer ends automatically
- updated setup and smoke-test docs for pause, restart, and completion flow

### Why It Matters

This closes the gameplay usability loop. The prototype now has a proper in-level pause flow, a restart path, a presentable end state, and cleaner player-facing guidance during recording and replay.

### How It Was Checked

- confirmed the runtime bootstrap targets gameplay scenes and skips `MainMenu`
- confirmed the pause flow is wired for resume, restart, and return-to-menu actions
- confirmed level completion now raises a dedicated event for UI flow
- confirmed recording feedback updates correctly when recording ends through the max-duration timer
- documented smoke tests for:
  - pause behavior
  - restart flow
  - return-to-menu flow
  - final completion overlay behavior
  - recording status transitions

### Follow-Up Work

- expand `SceneRegistry.CampaignLevels` when new gameplay scenes are added
- build SC-18 to SC-21 on top of the new completion flow
- replace runtime-generated UI with authored scene UI later if desired during polish
