### PR TITLE
feat(level): add campaign scene set and progression order

### DIFF
--- a/Assets/Scenes/Level_02_ButtonDoor.unity
+++ b/Assets/Scenes/Level_02_ButtonDoor.unity
@@ -160,7 +160,7 @@ Transform:
   m_GameObject: {fileID: 29042378}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -6.5, y: -2, z: 0}
+  m_LocalPosition: {x: -8, y: -2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -536,7 +536,7 @@ Transform:
   m_GameObject: {fileID: 217809865}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -1.5, y: -2.375, z: 0}
+  m_LocalPosition: {x: 0, y: -2.375, z: 0}
   m_LocalScale: {x: 1, y: 0.25, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1219,7 +1219,7 @@ Transform:
   m_GameObject: {fileID: 1210059138}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -6.5, y: -2, z: 0}
+  m_LocalPosition: {x: -8, y: -2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1389,7 +1389,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   playerController: {fileID: 1210059141}
   mechanicHudController: {fileID: 260943787}
-  completionMessage: Level 1 complete!
+  completionMessage: Level 2 complete!
   loadNextSceneOnComplete: 0
   nextSceneName: 
 --- !u!61 &1649930835
@@ -1498,7 +1498,7 @@ Transform:
   m_GameObject: {fileID: 1649930833}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 9.5, y: -2.55, z: 0}
+  m_LocalPosition: {x: 12.5, y: -2.55, z: 0}
   m_LocalScale: {x: 1, y: 2, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1647,7 +1647,7 @@ Transform:
   m_GameObject: {fileID: 1696415607}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 3.5, y: -1, z: 0}
+  m_LocalPosition: {x: 6, y: -1, z: 0}
   m_LocalScale: {x: 1, y: 3, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scenes/Level_02_ButtonDoor.unity.meta
+++ b/Assets/Scenes/Level_02_ButtonDoor.unity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3e42c4135b1f49dd9f8f0fc7b58efba4
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+

--- a/Assets/Scenes/Level_03_HazardTiming.unity
+++ b/Assets/Scenes/Level_03_HazardTiming.unity
@@ -160,7 +160,7 @@ Transform:
   m_GameObject: {fileID: 29042378}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -6.5, y: -2, z: 0}
+  m_LocalPosition: {x: -8, y: -2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -536,7 +536,7 @@ Transform:
   m_GameObject: {fileID: 217809865}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -1.5, y: -2.375, z: 0}
+  m_LocalPosition: {x: 0, y: -2.375, z: 0}
   m_LocalScale: {x: 1, y: 0.25, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -832,8 +832,8 @@ Transform:
   m_GameObject: {fileID: 924532919}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -18, y: -2.375, z: 0}
-  m_LocalScale: {x: 2, y: 0.25, z: 1}
+  m_LocalPosition: {x: 10, y: -2.375, z: 0}
+  m_LocalScale: {x: 4, y: 0.25, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -1219,7 +1219,7 @@ Transform:
   m_GameObject: {fileID: 1210059138}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -6.5, y: -2, z: 0}
+  m_LocalPosition: {x: -8, y: -2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1389,7 +1389,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   playerController: {fileID: 1210059141}
   mechanicHudController: {fileID: 260943787}
-  completionMessage: Level 1 complete!
+  completionMessage: Level 3 complete!
   loadNextSceneOnComplete: 0
   nextSceneName: 
 --- !u!61 &1649930835
@@ -1498,7 +1498,7 @@ Transform:
   m_GameObject: {fileID: 1649930833}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 9.5, y: -2.55, z: 0}
+  m_LocalPosition: {x: 16, y: -2.55, z: 0}
   m_LocalScale: {x: 1, y: 2, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1647,7 +1647,7 @@ Transform:
   m_GameObject: {fileID: 1696415607}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 3.5, y: -1, z: 0}
+  m_LocalPosition: {x: 5, y: -1, z: 0}
   m_LocalScale: {x: 1, y: 3, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scenes/Level_03_HazardTiming.unity.meta
+++ b/Assets/Scenes/Level_03_HazardTiming.unity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3555f50a6be84fbab95be7dbe23dfbfe
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+

--- a/Assets/Scenes/Level_04_Final.unity
+++ b/Assets/Scenes/Level_04_Final.unity
@@ -160,7 +160,7 @@ Transform:
   m_GameObject: {fileID: 29042378}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -6.5, y: -2, z: 0}
+  m_LocalPosition: {x: -10, y: -2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -536,7 +536,7 @@ Transform:
   m_GameObject: {fileID: 217809865}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -1.5, y: -2.375, z: 0}
+  m_LocalPosition: {x: -1, y: -2.375, z: 0}
   m_LocalScale: {x: 1, y: 0.25, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -832,8 +832,8 @@ Transform:
   m_GameObject: {fileID: 924532919}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -18, y: -2.375, z: 0}
-  m_LocalScale: {x: 2, y: 0.25, z: 1}
+  m_LocalPosition: {x: 11.5, y: -2.375, z: 0}
+  m_LocalScale: {x: 5, y: 0.25, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -1219,7 +1219,7 @@ Transform:
   m_GameObject: {fileID: 1210059138}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -6.5, y: -2, z: 0}
+  m_LocalPosition: {x: -10, y: -2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1389,7 +1389,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   playerController: {fileID: 1210059141}
   mechanicHudController: {fileID: 260943787}
-  completionMessage: Level 1 complete!
+  completionMessage: Prototype complete!
   loadNextSceneOnComplete: 0
   nextSceneName: 
 --- !u!61 &1649930835
@@ -1498,7 +1498,7 @@ Transform:
   m_GameObject: {fileID: 1649930833}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 9.5, y: -2.55, z: 0}
+  m_LocalPosition: {x: 19, y: -2.55, z: 0}
   m_LocalScale: {x: 1, y: 2, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1647,7 +1647,7 @@ Transform:
   m_GameObject: {fileID: 1696415607}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 3.5, y: -1, z: 0}
+  m_LocalPosition: {x: 6.5, y: -1, z: 0}
   m_LocalScale: {x: 1, y: 3, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scenes/Level_04_Final.unity.meta
+++ b/Assets/Scenes/Level_04_Final.unity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4c0f0b68d625484680f329bd4057e9da
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+

--- a/Assets/Scripts/Core/SceneRegistry.cs
+++ b/Assets/Scripts/Core/SceneRegistry.cs
@@ -4,11 +4,17 @@ namespace ShadowClone.Core
     {
         public const string MainMenu = "MainMenu";
         public const string Tutorial = "Level_01_Tutorial";
+        public const string ButtonDoor = "Level_02_ButtonDoor";
+        public const string HazardTiming = "Level_03_HazardTiming";
+        public const string Final = "Level_04_Final";
         public const string Prototype = "Gameplay_Prototype";
 
         public static readonly string[] CampaignLevels =
         {
-            Tutorial
+            Tutorial,
+            ButtonDoor,
+            HazardTiming,
+            Final
         };
 
         public static bool TryGetNextCampaignScene(string currentSceneName, out string nextSceneName)

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -11,4 +11,13 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/Level_01_Tutorial.unity
     guid: 01b730f569cb5a34cbc5327ca378168c
+  - enabled: 1
+    path: Assets/Scenes/Level_02_ButtonDoor.unity
+    guid: 3e42c4135b1f49dd9f8f0fc7b58efba4
+  - enabled: 1
+    path: Assets/Scenes/Level_03_HazardTiming.unity
+    guid: 3555f50a6be84fbab95be7dbe23dfbfe
+  - enabled: 1
+    path: Assets/Scenes/Level_04_Final.unity
+    guid: 4c0f0b68d625484680f329bd4057e9da
   m_configObjects: {}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ The format can stay simple:
 - Reusable `Hazard` trigger script and expanded room reset support for `SC-13`
 - Reusable `GoalZone` completion trigger and smoke-test guidance for `SC-14`
 - Runtime gameplay UI bootstrap for pause, restart, return-to-menu, and final completion flow for `SC-16` and `SC-17`
+- Initial four-level campaign scene set and progression order for `SC-18` through `SC-21`
 
 ### Changed
 

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -10,6 +10,7 @@ These rules cover the first implementation slice for SC-03 and are meant to keep
 - Use sub-namespaces by responsibility: `ShadowClone.Core`, `ShadowClone.Gameplay`, `ShadowClone.Clone`, `ShadowClone.UI`.
 - Use `PascalCase` for class names, public methods, and serialized property labels.
 - Keep scene names explicit and ordered: `MainMenu`, `Level_01_Tutorial`, `Level_02_ButtonDoor`, `Level_03_HazardTiming`, `Level_04_Final`.
+- Keep campaign scene order mirrored in `SceneRegistry.CampaignLevels` and in Build Settings.
 
 ## Script Ownership
 

--- a/docs/SMOKE_TEST_CHECKLIST.md
+++ b/docs/SMOKE_TEST_CHECKLIST.md
@@ -72,6 +72,15 @@ Use this checklist after wiring the scripts in the Unity editor.
 - Final completion state feels intentional rather than like a debug message.
 - When multiple campaign levels exist, completion can route to the next scene in order.
 
+## Campaign Levels
+
+- `Level_01_Tutorial` introduces the first safe button-door solve.
+- `Level_02_ButtonDoor` requires a longer button hold and run to the goal.
+- `Level_03_HazardTiming` adds a hazard strip after the door interaction.
+- `Level_04_Final` combines button-door timing and the widest hazard strip in the campaign.
+- `Next Level` can carry the player from level `1` through level `4`.
+- `Level_04_Final` ends on the prototype completion screen rather than loading another room.
+
 ## Readability
 
 - HUD text changes for ready, recording, blocked, replay, and reset states.

--- a/docs/UNITY_SETUP_GUIDE.md
+++ b/docs/UNITY_SETUP_GUIDE.md
@@ -17,9 +17,15 @@ This repo now includes the first gameplay script pass for SC-02 through SC-10, b
 3. Create these scenes under `Assets/Scenes/`:
    - `MainMenu`
    - `Level_01_Tutorial`
+   - `Level_02_ButtonDoor`
+   - `Level_03_HazardTiming`
+   - `Level_04_Final`
 4. Add the scenes to Build Settings in this order:
    - `MainMenu`
    - `Level_01_Tutorial`
+   - `Level_02_ButtonDoor`
+   - `Level_03_HazardTiming`
+   - `Level_04_Final`
 5. Make `MainMenu` scene index `0`.
 
 ## Suggested Scene Wiring
@@ -71,13 +77,28 @@ This repo now includes the first gameplay script pass for SC-02 through SC-10, b
 - Open `Level_01_Tutorial` and keep its `GoalZone` wired as before.
 - Enter Play Mode and solve the room.
 - Reach the goal and confirm a completion overlay appears.
-- Because the current campaign list contains only `Level_01_Tutorial`, confirm the overlay behaves as a final completion screen by showing:
+- Because the campaign list now includes `Level_01_Tutorial` through `Level_04_Final`, confirm the overlay shows `Next Level` in levels `1` to `3`.
+- Reach the goal in `Level_04_Final` and confirm the overlay behaves as a final completion screen by showing:
   - a completion title
   - a replay button
   - a return-to-menu button
-- Click `Replay Level` and confirm the room reloads.
+- Click `Replay Level` and confirm the current room reloads.
 - Reach the goal again, click `Return To Menu`, and confirm the project returns to `MainMenu`.
-- When more gameplay scenes are added later, update `SceneRegistry.CampaignLevels` so the same overlay can expose `Next Level`.
+
+### SC-18 To SC-21 Level Content Batch
+
+- Open each campaign scene directly and confirm it loads without missing references:
+  - `Level_01_Tutorial`
+  - `Level_02_ButtonDoor`
+  - `Level_03_HazardTiming`
+  - `Level_04_Final`
+- Confirm the room pacing escalates across the scenes:
+  - Level 1 teaches the basic button-door solve with no hazard pressure in the path
+  - Level 2 stretches the button-door timing into a longer run
+  - Level 3 adds a hazard strip after the door
+  - Level 4 combines the longer run with a wider hazard strip and the final goal
+- Start at `MainMenu`, press `Play`, and confirm `Next Level` can carry the player from level `1` through level `4`.
+- Reach the goal in `Level_04_Final` and confirm the game ends on the prototype completion overlay instead of trying to load another scene.
 
 ### SC-15 Main Menu And Scene Start Flow
 


### PR DESCRIPTION
## Update: SC-18 To SC-21 Level Content Batch

### What Changed

- added the first full campaign scene set:
  - `Level_01_Tutorial`
  - `Level_02_ButtonDoor`
  - `Level_03_HazardTiming`
  - `Level_04_Final`
- tuned the tutorial room into a safer onboarding layout
- created first-pass layouts for button-door, hazard-timing, and final mixed-challenge rooms
- expanded `SceneRegistry` with the campaign scene list and progression order
- updated Build Settings so the full campaign is included in standalone flow
- updated setup and smoke-test docs for the four-level campaign path

### Why It Matters

This moves the project from a single prototype room into a real playable campaign structure. The clone mechanic can now be demonstrated across a beginning, middle, escalation, and final challenge.

### How It Was Checked

- verified all four gameplay scenes exist in the repo
- verified Build Settings order now includes the full campaign
- confirmed completion messaging is distinct per level
- documented smoke tests for:
  - direct scene loading
  - next-level progression
  - final prototype completion behavior
  - difficulty escalation across the campaign

### Follow-Up Work

- refine puzzle readability and spacing inside each level
- tune difficulty and reset pacing across the full campaign
- continue polish passes for audio, visuals, and feel after level validation
