### PR TITLE
feat(presentation): add audio and visual feedback pass

### DIFF
--- a/Assets/Scripts/Core/MainMenuController.cs
+++ b/Assets/Scripts/Core/MainMenuController.cs
@@ -1,3 +1,4 @@
+using ShadowClone.Presentation;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -9,11 +10,13 @@ namespace ShadowClone.Core
 
         public void Play()
         {
+            PresentationFeedbackBootstrap.PlayMenuConfirm();
             SceneManager.LoadScene(gameplaySceneName);
         }
 
         public void Quit()
         {
+            PresentationFeedbackBootstrap.PlayMenuConfirm();
             if (Application.isEditor)
             {
 #if UNITY_EDITOR

--- a/Assets/Scripts/Gameplay/PlayerController.cs
+++ b/Assets/Scripts/Gameplay/PlayerController.cs
@@ -14,15 +14,23 @@ namespace ShadowClone.Gameplay
 
         private Rigidbody2D body;
         private float moveInput;
+        private bool wasGrounded;
 
         public bool IsGrounded => groundCheck != null && groundCheck.IsGrounded;
         public bool IsMovementLocked { get; private set; }
         public Vector2 Velocity => body != null ? body.velocity : Vector2.zero;
         public float FacingDirection { get; private set; } = 1f;
+        public event System.Action Jumped;
+        public event System.Action Landed;
 
         private void Awake()
         {
             body = GetComponent<Rigidbody2D>();
+        }
+
+        private void Start()
+        {
+            wasGrounded = IsGrounded;
         }
 
         private void Update()
@@ -47,7 +55,17 @@ namespace ShadowClone.Gameplay
             if (Input.GetButtonDown("Jump") && IsGrounded)
             {
                 body.velocity = new Vector2(body.velocity.x, jumpForce);
+                Jumped?.Invoke();
+                wasGrounded = false;
             }
+
+            bool isGroundedNow = IsGrounded;
+            if (!wasGrounded && isGroundedNow)
+            {
+                Landed?.Invoke();
+            }
+
+            wasGrounded = isGroundedNow;
         }
 
         private void FixedUpdate()

--- a/Assets/Scripts/Gameplay/PlayerFeedbackView.cs
+++ b/Assets/Scripts/Gameplay/PlayerFeedbackView.cs
@@ -11,14 +11,37 @@ namespace ShadowClone.Gameplay
         [SerializeField] private Color idleColor = Color.white;
         [SerializeField] private Color airborneColor = new Color(0.9f, 0.95f, 1f, 1f);
         [SerializeField] private Color recordingColor = new Color(1f, 0.85f, 0.45f, 1f);
+        [SerializeField] private float colorLerpSpeed = 8f;
+        [SerializeField] private float impactRecoverSpeed = 10f;
+        [SerializeField] private float jumpStretch = 0.12f;
+        [SerializeField] private float landingSquash = 0.18f;
 
         private Vector3 baseScale = Vector3.one;
+        private float stretchOffset;
+        private float squashOffset;
+        private Color currentColor = Color.white;
 
         private void Awake()
         {
             if (playerController != null)
             {
                 baseScale = playerController.transform.localScale;
+                playerController.Jumped += HandleJumped;
+                playerController.Landed += HandleLanded;
+            }
+
+            if (spriteRenderer != null)
+            {
+                currentColor = spriteRenderer.color;
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (playerController != null)
+            {
+                playerController.Jumped -= HandleJumped;
+                playerController.Landed -= HandleLanded;
             }
         }
 
@@ -31,6 +54,10 @@ namespace ShadowClone.Gameplay
 
             Vector3 nextScale = baseScale;
             nextScale.x = Mathf.Abs(baseScale.x) * playerController.FacingDirection;
+            squashOffset = Mathf.MoveTowards(squashOffset, 0f, impactRecoverSpeed * Time.deltaTime);
+            stretchOffset = Mathf.MoveTowards(stretchOffset, 0f, impactRecoverSpeed * Time.deltaTime);
+            nextScale.y *= 1f + stretchOffset - squashOffset;
+            nextScale.x *= 1f - stretchOffset + squashOffset;
             playerController.transform.localScale = nextScale;
 
             if (spriteRenderer == null)
@@ -38,18 +65,34 @@ namespace ShadowClone.Gameplay
                 return;
             }
 
+            Color targetColor;
             if (recordingController != null && recordingController.IsRecording)
             {
-                spriteRenderer.color = recordingColor;
+                targetColor = recordingColor;
             }
             else if (!playerController.IsGrounded)
             {
-                spriteRenderer.color = airborneColor;
+                targetColor = airborneColor;
             }
             else
             {
-                spriteRenderer.color = idleColor;
+                targetColor = idleColor;
             }
+
+            currentColor = Color.Lerp(currentColor, targetColor, colorLerpSpeed * Time.deltaTime);
+            spriteRenderer.color = currentColor;
+        }
+
+        private void HandleJumped()
+        {
+            stretchOffset = jumpStretch;
+            squashOffset = 0f;
+        }
+
+        private void HandleLanded()
+        {
+            squashOffset = landingSquash;
+            stretchOffset = 0f;
         }
     }
 }

--- a/Assets/Scripts/Level/DoorController.cs
+++ b/Assets/Scripts/Level/DoorController.cs
@@ -10,12 +10,32 @@ namespace ShadowClone.Level
         [SerializeField] private Color closedColor = new Color(0.9f, 0.25f, 0.25f, 1f);
         [SerializeField] private Color openColor = new Color(0.35f, 0.95f, 0.55f, 0.35f);
         [SerializeField] private bool startOpen;
+        [SerializeField] private float openScaleY = 0.2f;
+        [SerializeField] private float transitionSpeed = 8f;
+
+        private Vector3 baseScale;
 
         public bool IsOpen { get; private set; }
+        public event System.Action<bool> StateChanged;
 
         private void Awake()
         {
+            baseScale = transform.localScale;
             ApplyState(startOpen);
+        }
+
+        private void Update()
+        {
+            Vector3 targetScale = IsOpen
+                ? new Vector3(baseScale.x, baseScale.y * openScaleY, baseScale.z)
+                : baseScale;
+            transform.localScale = Vector3.Lerp(transform.localScale, targetScale, transitionSpeed * Time.deltaTime);
+
+            if (targetRenderer != null)
+            {
+                Color targetColor = IsOpen ? openColor : closedColor;
+                targetRenderer.color = Color.Lerp(targetRenderer.color, targetColor, transitionSpeed * Time.deltaTime);
+            }
         }
 
         private void OnEnable()
@@ -70,6 +90,7 @@ namespace ShadowClone.Level
 
         private void ApplyState(bool shouldOpen)
         {
+            bool wasOpen = IsOpen;
             IsOpen = shouldOpen;
 
             if (blockingCollider != null)
@@ -77,9 +98,9 @@ namespace ShadowClone.Level
                 blockingCollider.enabled = !IsOpen;
             }
 
-            if (targetRenderer != null)
+            if (!wasOpen.Equals(IsOpen))
             {
-                targetRenderer.color = IsOpen ? openColor : closedColor;
+                StateChanged?.Invoke(IsOpen);
             }
         }
     }

--- a/Assets/Scripts/Level/GoalZone.cs
+++ b/Assets/Scripts/Level/GoalZone.cs
@@ -14,6 +14,10 @@ namespace ShadowClone.Level
         [SerializeField] private string completionMessage = "Level complete!";
         [SerializeField] private bool loadNextSceneOnComplete;
         [SerializeField] private string nextSceneName;
+        [SerializeField] private SpriteRenderer targetRenderer;
+        [SerializeField] private Color idleColor = new Color(0.2f, 0.86f, 1f, 1f);
+        [SerializeField] private Color completeColor = new Color(1f, 0.95f, 0.45f, 1f);
+        [SerializeField] private float pulseSpeed = 3f;
 
         private Collider2D triggerCollider;
         private bool isCompleted;
@@ -25,6 +29,23 @@ namespace ShadowClone.Level
         {
             triggerCollider = GetComponent<Collider2D>();
             triggerCollider.isTrigger = true;
+        }
+
+        private void Update()
+        {
+            if (targetRenderer == null)
+            {
+                return;
+            }
+
+            if (isCompleted)
+            {
+                targetRenderer.color = Color.Lerp(targetRenderer.color, completeColor, 8f * Time.deltaTime);
+                return;
+            }
+
+            float pulse = (Mathf.Sin(Time.time * pulseSpeed) + 1f) * 0.5f;
+            targetRenderer.color = Color.Lerp(idleColor * 0.8f, idleColor, pulse);
         }
 
         private void OnValidate()

--- a/Assets/Scripts/Level/Hazard.cs
+++ b/Assets/Scripts/Level/Hazard.cs
@@ -9,13 +9,29 @@ namespace ShadowClone.Level
     {
         [SerializeField] private RoomResetManager roomResetManager;
         [SerializeField] private string resetReason = "Hazard hit";
+        [SerializeField] private SpriteRenderer targetRenderer;
+        [SerializeField] private Color baseColor = new Color(1f, 0.45f, 0.45f, 1f);
+        [SerializeField] private Color pulseColor = new Color(1f, 0.8f, 0.35f, 1f);
+        [SerializeField] private float pulseSpeed = 6f;
 
         private Collider2D triggerCollider;
+        public event System.Action Triggered;
 
         private void Awake()
         {
             triggerCollider = GetComponent<Collider2D>();
             triggerCollider.isTrigger = true;
+        }
+
+        private void Update()
+        {
+            if (targetRenderer == null)
+            {
+                return;
+            }
+
+            float pulse = (Mathf.Sin(Time.time * pulseSpeed) + 1f) * 0.5f;
+            targetRenderer.color = Color.Lerp(baseColor, pulseColor, pulse);
         }
 
         private void OnValidate()
@@ -39,6 +55,7 @@ namespace ShadowClone.Level
                 return;
             }
 
+            Triggered?.Invoke();
             roomResetManager.RequestReset(resetReason);
         }
     }

--- a/Assets/Scripts/Level/PuzzleButton.cs
+++ b/Assets/Scripts/Level/PuzzleButton.cs
@@ -14,9 +14,13 @@ namespace ShadowClone.Level
         [SerializeField] private Color activeColor = new Color(0.35f, 0.9f, 0.45f, 1f);
         [SerializeField] private bool reactToPlayer = true;
         [SerializeField] private bool reactToClone = true;
+        [SerializeField] private float activePulseAmplitude = 0.08f;
+        [SerializeField] private float activePulseSpeed = 4f;
+        [SerializeField] private float pressedScaleY = 0.82f;
 
         private readonly HashSet<Collider2D> occupants = new HashSet<Collider2D>();
         private Collider2D triggerCollider;
+        private Vector3 baseScale;
 
         public event Action<bool> PressedStateChanged;
 
@@ -26,7 +30,31 @@ namespace ShadowClone.Level
         {
             triggerCollider = GetComponent<Collider2D>();
             triggerCollider.isTrigger = true;
+            baseScale = transform.localScale;
             UpdateVisual();
+        }
+
+        private void Update()
+        {
+            float targetY = IsPressed ? pressedScaleY : 1f;
+            Vector3 targetScale = new Vector3(baseScale.x, baseScale.y * targetY, baseScale.z);
+            transform.localScale = Vector3.Lerp(transform.localScale, targetScale, 10f * Time.deltaTime);
+
+            if (targetRenderer == null)
+            {
+                return;
+            }
+
+            if (IsPressed)
+            {
+                float pulse = 1f + Mathf.Sin(Time.time * activePulseSpeed) * activePulseAmplitude;
+                targetRenderer.color = activeColor * pulse;
+                targetRenderer.color = new Color(targetRenderer.color.r, targetRenderer.color.g, targetRenderer.color.b, 1f);
+            }
+            else
+            {
+                targetRenderer.color = Color.Lerp(targetRenderer.color, inactiveColor, 10f * Time.deltaTime);
+            }
         }
 
         private void OnValidate()

--- a/Assets/Scripts/Presentation.meta
+++ b/Assets/Scripts/Presentation.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a6de7ba7ccbb153469f26b005abccb07
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Presentation/PresentationFeedbackBootstrap.cs
+++ b/Assets/Scripts/Presentation/PresentationFeedbackBootstrap.cs
@@ -1,0 +1,514 @@
+using ShadowClone.Clone;
+using ShadowClone.Core;
+using ShadowClone.Gameplay;
+using ShadowClone.Level;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace ShadowClone.Presentation
+{
+    public class PresentationFeedbackBootstrap : MonoBehaviour
+    {
+        private enum WaveShape
+        {
+            Sine,
+            Triangle,
+            Square,
+            SoftNoise
+        }
+
+        private const string BootstrapObjectName = "PresentationFeedbackBootstrap";
+        private static PresentationFeedbackBootstrap instance;
+
+        private AudioSource sfxSource;
+        private AudioSource ambienceSource;
+        private AudioClip jumpClip;
+        private AudioClip landClip;
+        private AudioClip recordStartClip;
+        private AudioClip recordStopClip;
+        private AudioClip replayClip;
+        private AudioClip buttonClip;
+        private AudioClip doorOpenClip;
+        private AudioClip doorCloseClip;
+        private AudioClip hazardClip;
+        private AudioClip completeClip;
+        private AudioClip menuClip;
+        private AudioClip pauseClip;
+        private AudioClip restartClip;
+        private AudioClip levelStartClip;
+        private AudioClip menuAmbienceClip;
+        private AudioClip tutorialAmbienceClip;
+        private AudioClip buttonDoorAmbienceClip;
+        private AudioClip hazardTimingAmbienceClip;
+        private AudioClip finalAmbienceClip;
+
+        private PlayerController playerController;
+        private RecordingController recordingController;
+        private CloneReplayController cloneReplayController;
+        private PuzzleButton[] buttons = System.Array.Empty<PuzzleButton>();
+        private DoorController[] doors = System.Array.Empty<DoorController>();
+        private Hazard[] hazards = System.Array.Empty<Hazard>();
+        private GoalZone[] goals = System.Array.Empty<GoalZone>();
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void Bootstrap()
+        {
+            if (instance != null)
+            {
+                return;
+            }
+
+            GameObject bootstrapObject = new GameObject(BootstrapObjectName);
+            bootstrapObject.AddComponent<PresentationFeedbackBootstrap>();
+        }
+
+        public static void PlayMenuConfirm()
+        {
+            instance?.PlayClip(instance.menuClip, 0.3f);
+        }
+
+        public static void PlayPauseToggle()
+        {
+            instance?.PlayClip(instance.pauseClip, 0.22f);
+        }
+
+        public static void PlayRestartLevel()
+        {
+            instance?.PlayClip(instance.restartClip, 0.24f);
+        }
+
+        public static void PlayLevelStart()
+        {
+            instance?.PlayClip(instance.levelStartClip, 0.22f);
+        }
+
+        private void Awake()
+        {
+            if (instance != null && instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+
+            sfxSource = gameObject.AddComponent<AudioSource>();
+            sfxSource.playOnAwake = false;
+            sfxSource.loop = false;
+            sfxSource.spatialBlend = 0f;
+            sfxSource.ignoreListenerPause = true;
+
+            ambienceSource = gameObject.AddComponent<AudioSource>();
+            ambienceSource.playOnAwake = false;
+            ambienceSource.loop = true;
+            ambienceSource.spatialBlend = 0f;
+            ambienceSource.ignoreListenerPause = true;
+            ambienceSource.volume = 0.42f;
+
+            BuildClips();
+            SceneManager.sceneLoaded += HandleSceneLoaded;
+            HandleSceneLoaded(SceneManager.GetActiveScene(), LoadSceneMode.Single);
+        }
+
+        private void OnDestroy()
+        {
+            if (instance == this)
+            {
+                SceneManager.sceneLoaded -= HandleSceneLoaded;
+                instance = null;
+            }
+
+            UnbindSceneFeedback();
+        }
+
+        private void HandleSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            UnbindSceneFeedback();
+
+            if (scene.name == SceneRegistry.MainMenu)
+            {
+                PlayAmbience(menuAmbienceClip, 0.32f);
+                return;
+            }
+
+            PlayAmbience(GetLevelAmbience(scene.name), 0.3f);
+            PlayLevelStart();
+
+            playerController = FindObjectOfType<PlayerController>();
+            recordingController = FindObjectOfType<RecordingController>();
+            cloneReplayController = FindObjectOfType<CloneReplayController>();
+            buttons = FindObjectsOfType<PuzzleButton>();
+            doors = FindObjectsOfType<DoorController>();
+            hazards = FindObjectsOfType<Hazard>();
+            goals = FindObjectsOfType<GoalZone>();
+
+            if (playerController != null)
+            {
+                playerController.Jumped += HandleJumped;
+                playerController.Landed += HandleLanded;
+            }
+
+            if (recordingController != null)
+            {
+                recordingController.RecordingStateChanged += HandleRecordingStateChanged;
+                recordingController.RecordingFinished += HandleRecordingFinished;
+            }
+
+            if (cloneReplayController != null)
+            {
+                cloneReplayController.ReplayStarted += HandleReplayStarted;
+            }
+
+            for (int i = 0; i < buttons.Length; i++)
+            {
+                buttons[i].PressedStateChanged += HandleButtonPressedStateChanged;
+            }
+
+            for (int i = 0; i < doors.Length; i++)
+            {
+                doors[i].StateChanged += HandleDoorStateChanged;
+            }
+
+            for (int i = 0; i < hazards.Length; i++)
+            {
+                hazards[i].Triggered += HandleHazardTriggered;
+            }
+
+            for (int i = 0; i < goals.Length; i++)
+            {
+                goals[i].Completed += HandleGoalCompleted;
+            }
+        }
+
+        private void UnbindSceneFeedback()
+        {
+            if (playerController != null)
+            {
+                playerController.Jumped -= HandleJumped;
+                playerController.Landed -= HandleLanded;
+                playerController = null;
+            }
+
+            if (recordingController != null)
+            {
+                recordingController.RecordingStateChanged -= HandleRecordingStateChanged;
+                recordingController.RecordingFinished -= HandleRecordingFinished;
+                recordingController = null;
+            }
+
+            if (cloneReplayController != null)
+            {
+                cloneReplayController.ReplayStarted -= HandleReplayStarted;
+                cloneReplayController = null;
+            }
+
+            for (int i = 0; i < buttons.Length; i++)
+            {
+                if (buttons[i] != null)
+                {
+                    buttons[i].PressedStateChanged -= HandleButtonPressedStateChanged;
+                }
+            }
+
+            for (int i = 0; i < doors.Length; i++)
+            {
+                if (doors[i] != null)
+                {
+                    doors[i].StateChanged -= HandleDoorStateChanged;
+                }
+            }
+
+            for (int i = 0; i < hazards.Length; i++)
+            {
+                if (hazards[i] != null)
+                {
+                    hazards[i].Triggered -= HandleHazardTriggered;
+                }
+            }
+
+            for (int i = 0; i < goals.Length; i++)
+            {
+                if (goals[i] != null)
+                {
+                    goals[i].Completed -= HandleGoalCompleted;
+                }
+            }
+
+            buttons = System.Array.Empty<PuzzleButton>();
+            doors = System.Array.Empty<DoorController>();
+            hazards = System.Array.Empty<Hazard>();
+            goals = System.Array.Empty<GoalZone>();
+        }
+
+        private void HandleJumped()
+        {
+            PlayClip(jumpClip, 0.26f);
+        }
+
+        private void HandleLanded()
+        {
+            PlayClip(landClip, 0.22f);
+        }
+
+        private void HandleRecordingStateChanged(bool isRecording)
+        {
+            if (isRecording)
+            {
+                PlayClip(recordStartClip, 0.24f);
+            }
+        }
+
+        private void HandleRecordingFinished(RecordingClip clip)
+        {
+            PlayClip(recordStopClip, 0.24f);
+        }
+
+        private void HandleReplayStarted()
+        {
+            PlayClip(replayClip, 0.24f);
+        }
+
+        private void HandleButtonPressedStateChanged(bool isPressed)
+        {
+            if (isPressed)
+            {
+                PlayClip(buttonClip, 0.22f);
+            }
+        }
+
+        private void HandleDoorStateChanged(bool isOpen)
+        {
+            PlayClip(isOpen ? doorOpenClip : doorCloseClip, 0.2f);
+        }
+
+        private void HandleHazardTriggered()
+        {
+            PlayClip(hazardClip, 0.28f);
+        }
+
+        private void HandleGoalCompleted()
+        {
+            PlayClip(completeClip, 0.28f);
+        }
+
+        private void PlayClip(AudioClip clip, float volumeScale)
+        {
+            if (clip == null || sfxSource == null)
+            {
+                return;
+            }
+
+            sfxSource.PlayOneShot(clip, volumeScale);
+        }
+
+        private void PlayAmbience(AudioClip clip, float volume)
+        {
+            if (clip == null || ambienceSource == null)
+            {
+                return;
+            }
+
+            if (ambienceSource.clip == clip && ambienceSource.isPlaying)
+            {
+                ambienceSource.volume = volume;
+                return;
+            }
+
+            ambienceSource.Stop();
+            ambienceSource.clip = clip;
+            ambienceSource.volume = volume;
+            ambienceSource.Play();
+        }
+
+        private void BuildClips()
+        {
+            jumpClip = BuildSweepClip("jump", WaveShape.Triangle, 380f, 0.12f, 0.18f, 760f, 0.01f, 0f);
+            landClip = BuildSweepClip("land", WaveShape.Sine, 210f, 0.11f, 0.22f, 120f, 0f, 0.05f);
+            recordStartClip = BuildSweepClip("recordStart", WaveShape.Square, 640f, 0.13f, 0.16f, 920f, 0.02f, 0f);
+            recordStopClip = BuildSweepClip("recordStop", WaveShape.Triangle, 920f, 0.13f, 0.16f, 420f, 0.015f, 0f);
+            replayClip = BuildReplayClip("replay");
+            buttonClip = BuildSweepClip("button", WaveShape.Square, 280f, 0.1f, 0.12f, 240f, 0f, 0f);
+            doorOpenClip = BuildSweepClip("doorOpen", WaveShape.Sine, 150f, 0.24f, 0.18f, 340f, 0.01f, 0.02f);
+            doorCloseClip = BuildSweepClip("doorClose", WaveShape.Sine, 300f, 0.2f, 0.16f, 130f, 0.005f, 0.03f);
+            hazardClip = BuildNoiseBurstClip("hazard", 0.16f, 0.22f, 220f);
+            completeClip = BuildChordClip("complete", 0.42f, 0.15f, new[] { 392f, 523.25f, 659.25f });
+            menuClip = BuildChordClip("menu", 0.16f, 0.12f, new[] { 392f, 523.25f });
+            pauseClip = BuildSweepClip("pause", WaveShape.Triangle, 540f, 0.11f, 0.13f, 320f, 0f, 0f);
+            restartClip = BuildSweepClip("restart", WaveShape.Square, 300f, 0.15f, 0.14f, 620f, 0.01f, 0.01f);
+            levelStartClip = BuildChordClip("levelStart", 0.22f, 0.11f, new[] { 349.23f, 440f, 523.25f });
+            menuAmbienceClip = BuildAmbientLoop("menuAmbience", 5.5f, 95f, 165f, 0.035f, 0.02f);
+            tutorialAmbienceClip = BuildAmbientLoop("tutorialAmbience", 6.0f, 78f, 128f, 0.028f, 0.01f);
+            buttonDoorAmbienceClip = BuildAmbientLoop("buttonDoorAmbience", 6.2f, 70f, 110f, 0.032f, 0.012f);
+            hazardTimingAmbienceClip = BuildAmbientLoop("hazardTimingAmbience", 6.4f, 62f, 98f, 0.035f, 0.016f);
+            finalAmbienceClip = BuildAmbientLoop("finalAmbience", 6.8f, 58f, 92f, 0.038f, 0.018f);
+        }
+
+        private AudioClip BuildSweepClip(string clipName, WaveShape shape, float startFrequency, float duration, float amplitude, float endFrequency, float vibratoAmount, float noiseMix)
+        {
+            const int sampleRate = 44100;
+            int sampleCount = Mathf.CeilToInt(sampleRate * duration);
+            float[] samples = new float[sampleCount];
+            float phase = 0f;
+            Random.State previousRandomState = Random.state;
+            Random.InitState(clipName.GetHashCode());
+
+            for (int i = 0; i < sampleCount; i++)
+            {
+                float t = (float)i / sampleCount;
+                float frequency = Mathf.Lerp(startFrequency, endFrequency, t);
+                frequency += Mathf.Sin(t * Mathf.PI * 8f) * startFrequency * vibratoAmount;
+                phase += 2f * Mathf.PI * frequency / sampleRate;
+
+                float attack = Mathf.Clamp01(t / 0.15f);
+                float release = Mathf.Clamp01((1f - t) / 0.35f);
+                float envelope = attack * release;
+
+                float waveform = EvaluateWave(shape, phase);
+                float noise = (Random.value * 2f - 1f) * noiseMix;
+                samples[i] = Mathf.Clamp((waveform + noise) * amplitude * envelope, -1f, 1f);
+            }
+
+            Random.state = previousRandomState;
+            return CreateClip(clipName, samples, sampleRate);
+        }
+
+        private AudioClip BuildNoiseBurstClip(string clipName, float duration, float amplitude, float filterFrequency)
+        {
+            const int sampleRate = 44100;
+            int sampleCount = Mathf.CeilToInt(sampleRate * duration);
+            float[] samples = new float[sampleCount];
+            float lastValue = 0f;
+            Random.State previousRandomState = Random.state;
+            Random.InitState(clipName.GetHashCode());
+
+            for (int i = 0; i < sampleCount; i++)
+            {
+                float t = (float)i / sampleCount;
+                float noise = Random.value * 2f - 1f;
+                float cutoff = Mathf.Lerp(filterFrequency * 2.2f, filterFrequency * 0.6f, t);
+                float lerp = Mathf.Clamp01(cutoff / sampleRate * 18f);
+                lastValue = Mathf.Lerp(lastValue, noise, lerp);
+                float envelope = Mathf.Sin(Mathf.PI * Mathf.Clamp01(1f - Mathf.Abs(t - 0.5f) * 2f));
+                samples[i] = lastValue * amplitude * envelope;
+            }
+
+            Random.state = previousRandomState;
+            return CreateClip(clipName, samples, sampleRate);
+        }
+
+        private AudioClip BuildChordClip(string clipName, float duration, float amplitude, float[] notes)
+        {
+            const int sampleRate = 44100;
+            int sampleCount = Mathf.CeilToInt(sampleRate * duration);
+            float[] samples = new float[sampleCount];
+            float[] phases = new float[notes.Length];
+
+            for (int i = 0; i < sampleCount; i++)
+            {
+                float t = (float)i / sampleCount;
+                float envelope = Mathf.Sin(Mathf.PI * Mathf.Clamp01(t));
+                float value = 0f;
+
+                for (int n = 0; n < notes.Length; n++)
+                {
+                    phases[n] += 2f * Mathf.PI * notes[n] / sampleRate;
+                    value += Mathf.Sin(phases[n]) * (1f / notes.Length);
+                }
+
+                samples[i] = value * amplitude * envelope;
+            }
+
+            return CreateClip(clipName, samples, sampleRate);
+        }
+
+        private AudioClip BuildReplayClip(string clipName)
+        {
+            const int sampleRate = 44100;
+            const float duration = 0.18f;
+            int sampleCount = Mathf.CeilToInt(sampleRate * duration);
+            float[] samples = new float[sampleCount];
+            float phaseA = 0f;
+            float phaseB = 0f;
+
+            for (int i = 0; i < sampleCount; i++)
+            {
+                float t = (float)i / sampleCount;
+                float freqA = Mathf.Lerp(260f, 540f, t);
+                float freqB = Mathf.Lerp(390f, 780f, t);
+                phaseA += 2f * Mathf.PI * freqA / sampleRate;
+                phaseB += 2f * Mathf.PI * freqB / sampleRate;
+                float envelope = Mathf.Clamp01((1f - t) * 1.2f);
+                float tone = EvaluateWave(WaveShape.Square, phaseA) * 0.6f + EvaluateWave(WaveShape.Triangle, phaseB) * 0.4f;
+                samples[i] = tone * 0.18f * envelope;
+            }
+
+            return CreateClip(clipName, samples, sampleRate);
+        }
+
+        private AudioClip BuildAmbientLoop(string clipName, float duration, float baseFrequencyA, float baseFrequencyB, float amplitude, float pulseAmplitude)
+        {
+            const int sampleRate = 44100;
+            int sampleCount = Mathf.CeilToInt(sampleRate * duration);
+            float[] samples = new float[sampleCount];
+            float phaseA = 0f;
+            float phaseB = 0f;
+            float phasePulse = 0f;
+
+            for (int i = 0; i < sampleCount; i++)
+            {
+                float t = (float)i / sampleCount;
+                float slowMotion = Mathf.Sin(t * Mathf.PI * 2f);
+                phaseA += 2f * Mathf.PI * (baseFrequencyA + slowMotion * 2f) / sampleRate;
+                phaseB += 2f * Mathf.PI * (baseFrequencyB + slowMotion * 3f) / sampleRate;
+                phasePulse += 2f * Mathf.PI * 0.7f / sampleRate;
+
+                float drone = Mathf.Sin(phaseA) * 0.65f + Mathf.Sin(phaseB) * 0.35f;
+                float pulse = Mathf.Sin(phasePulse) * pulseAmplitude;
+                float fade = Mathf.Sin(Mathf.PI * t);
+                samples[i] = (drone * amplitude + pulse) * (0.5f + fade * 0.5f);
+            }
+
+            return CreateClip(clipName, samples, sampleRate);
+        }
+
+        private AudioClip GetLevelAmbience(string sceneName)
+        {
+            switch (sceneName)
+            {
+                case SceneRegistry.Tutorial:
+                    return tutorialAmbienceClip;
+                case SceneRegistry.ButtonDoor:
+                    return buttonDoorAmbienceClip;
+                case SceneRegistry.HazardTiming:
+                    return hazardTimingAmbienceClip;
+                case SceneRegistry.Final:
+                    return finalAmbienceClip;
+                default:
+                    return tutorialAmbienceClip;
+            }
+        }
+
+        private static float EvaluateWave(WaveShape shape, float phase)
+        {
+            switch (shape)
+            {
+                case WaveShape.Triangle:
+                    return Mathf.PingPong(phase / Mathf.PI, 2f) - 1f;
+                case WaveShape.Square:
+                    return Mathf.Sign(Mathf.Sin(phase));
+                case WaveShape.SoftNoise:
+                    return (Mathf.PerlinNoise(phase, 0f) * 2f) - 1f;
+                default:
+                    return Mathf.Sin(phase);
+            }
+        }
+
+        private static AudioClip CreateClip(string clipName, float[] samples, int sampleRate)
+        {
+            AudioClip clip = AudioClip.Create(clipName, samples.Length, 1, sampleRate, false);
+            clip.SetData(samples, 0);
+            return clip;
+        }
+    }
+}

--- a/Assets/Scripts/Presentation/PresentationFeedbackBootstrap.cs.meta
+++ b/Assets/Scripts/Presentation/PresentationFeedbackBootstrap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ca0a78077d14ffcbdf0f24d42742aaa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/GameplayUiBootstrap.cs
+++ b/Assets/Scripts/UI/GameplayUiBootstrap.cs
@@ -2,6 +2,7 @@ using ShadowClone.Clone;
 using ShadowClone.Core;
 using ShadowClone.Gameplay;
 using ShadowClone.Level;
+using ShadowClone.Presentation;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
@@ -179,6 +180,7 @@ namespace ShadowClone.UI
             isPaused = paused;
             pausePanel.SetActive(paused);
             ApplyInteractiveState(paused);
+            PresentationFeedbackBootstrap.PlayPauseToggle();
         }
 
         private void ApplyInteractiveState(bool locked)
@@ -208,12 +210,14 @@ namespace ShadowClone.UI
 
         private void RestartRoom()
         {
+            PresentationFeedbackBootstrap.PlayRestartLevel();
             Time.timeScale = 1f;
             SceneManager.LoadScene(SceneManager.GetActiveScene().name);
         }
 
         private void ReturnToMenu()
         {
+            PresentationFeedbackBootstrap.PlayMenuConfirm();
             Time.timeScale = 1f;
             SceneManager.LoadScene(SceneRegistry.MainMenu);
         }

--- a/docs/AUDIO_PLAN.md
+++ b/docs/AUDIO_PLAN.md
@@ -27,6 +27,7 @@ If added:
 
 - Use one subtle ambient sci-fi loop for gameplay
 - Use one lightweight menu loop if available
+- Different gameplay loops per level are acceptable if they stay subtle and preserve the same sci-fi mood
 
 Music is lower priority than responsive sound effects.
 
@@ -36,6 +37,7 @@ Music is lower priority than responsive sound effects.
 - Avoid loud or harsh sounds
 - Make hazards and success states distinct
 - Lower music volume under UI and gameplay feedback
+- Transition / UI sounds should stay shorter and quieter than gameplay feedback
 
 ## Implementation Notes
 
@@ -43,6 +45,7 @@ Music is lower priority than responsive sound effects.
 - Use inspector-assigned audio clips
 - Avoid complex dynamic music systems
 - Ship with a tiny, polished set instead of many weak sounds
+- Runtime-generated placeholder tones are acceptable during the presentation batch before final sourced audio is chosen
 
 ## Asset Sourcing
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,8 @@ The format can stay simple:
 - Reusable `GoalZone` completion trigger and smoke-test guidance for `SC-14`
 - Runtime gameplay UI bootstrap for pause, restart, return-to-menu, and final completion flow for `SC-16` and `SC-17`
 - Initial four-level campaign scene set and progression order for `SC-18` through `SC-21`
+- Runtime placeholder audio cues, stronger object feedback, and first presentation tuning pass for `SC-22` through `SC-24`
+- Scene-specific ambient music layers and dedicated pause / restart / level-start cues
 
 ### Changed
 

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -7,7 +7,7 @@ These rules cover the first implementation slice for SC-03 and are meant to keep
 ## Naming
 
 - Use the root namespace `ShadowClone`.
-- Use sub-namespaces by responsibility: `ShadowClone.Core`, `ShadowClone.Gameplay`, `ShadowClone.Clone`, `ShadowClone.UI`.
+- Use sub-namespaces by responsibility: `ShadowClone.Core`, `ShadowClone.Gameplay`, `ShadowClone.Clone`, `ShadowClone.Level`, `ShadowClone.UI`, `ShadowClone.Presentation`.
 - Use `PascalCase` for class names, public methods, and serialized property labels.
 - Keep scene names explicit and ordered: `MainMenu`, `Level_01_Tutorial`, `Level_02_ButtonDoor`, `Level_03_HazardTiming`, `Level_04_Final`.
 - Keep campaign scene order mirrored in `SceneRegistry.CampaignLevels` and in Build Settings.
@@ -20,6 +20,7 @@ These rules cover the first implementation slice for SC-03 and are meant to keep
 - `Level/`: puzzle objects such as buttons, doors, hazards, and goals.
 - `UI/`: simple HUD and player-readable mechanic feedback.
 - `UI/GameplayUiBootstrap` owns runtime pause / completion overlays for gameplay scenes.
+- `Presentation/`: runtime audio and visual polish bootstrap behavior.
 
 ## Practical Rules
 
@@ -45,6 +46,7 @@ These rules cover the first implementation slice for SC-03 and are meant to keep
 - `GoalZone` owns level-complete trigger detection and minimal completion handoff.
 - `MechanicHudController` owns simple text feedback to the player.
 - `GameplayUiBootstrap` owns pause, restart, return-to-menu, and completion-screen wiring.
+- `PresentationFeedbackBootstrap` owns runtime placeholder SFX hookups for moment-to-moment gameplay feedback.
 
 ## Guardrails
 

--- a/docs/SMOKE_TEST_CHECKLIST.md
+++ b/docs/SMOKE_TEST_CHECKLIST.md
@@ -81,6 +81,27 @@ Use this checklist after wiring the scripts in the Unity editor.
 - `Next Level` can carry the player from level `1` through level `4`.
 - `Level_04_Final` ends on the prototype completion screen rather than loading another room.
 
+## Presentation
+
+- Jump and landing both produce short readable audio feedback.
+- Start recording, stop recording, replay, button press, door open/close, hazard hit, and level completion all produce distinct audio cues.
+- Main menu `Play` and `Quit` produce a confirmation sound.
+- Pause toggle produces a dedicated sound.
+- Restarting a room produces a dedicated restart sound.
+- Entering a gameplay level produces a level-start sound.
+- `MainMenu`, `Level_01_Tutorial`, `Level_02_ButtonDoor`, `Level_03_HazardTiming`, and `Level_04_Final` each have their own matching ambient loop or background music layer.
+- Player feedback transitions smoothly between idle, airborne, and recording states.
+- Buttons visibly compress and pulse while held.
+- Doors visually shrink/fade open instead of only toggling collision.
+- Hazards pulse clearly enough to read as dangerous at a glance.
+- Goals pulse while idle and brighten on completion.
+
+## Tuning
+
+- Tutorial text and mechanic status no longer overlap.
+- HUD remains readable during record / replay / reset states.
+- Level escalation still feels fair after the polish pass.
+
 ## Readability
 
 - HUD text changes for ready, recording, blocked, replay, and reset states.

--- a/docs/UNITY_SETUP_GUIDE.md
+++ b/docs/UNITY_SETUP_GUIDE.md
@@ -100,6 +100,36 @@ This repo now includes the first gameplay script pass for SC-02 through SC-10, b
 - Start at `MainMenu`, press `Play`, and confirm `Next Level` can carry the player from level `1` through level `4`.
 - Reach the goal in `Level_04_Final` and confirm the game ends on the prototype completion overlay instead of trying to load another scene.
 
+### SC-22 To SC-24 Presentation Batch
+
+- Enter Play Mode in `MainMenu` and confirm `Play` and `Quit` produce a short confirmation sound.
+- Leave `MainMenu` open for a few seconds and confirm it has its own ambient background layer.
+- Open any gameplay scene and confirm placeholder audio plays for:
+  - jump
+  - landing
+  - record start
+  - record finish
+  - replay start
+  - button press
+  - door open / close
+  - hazard hit
+  - level complete
+- Pause with `Esc` and confirm a dedicated pause sound plays.
+- Click `Restart Room` and confirm a distinct restart sound plays before the room reloads.
+- Move from one gameplay level to the next and confirm the level-start cue plays once when the new scene opens.
+- Confirm each gameplay scene now has its own matching ambient background:
+  - `Level_01_Tutorial`
+  - `Level_02_ButtonDoor`
+  - `Level_03_HazardTiming`
+  - `Level_04_Final`
+- Confirm the player sprite color transitions smoothly instead of snapping between states.
+- Confirm the player gets a small stretch on jump and squash on landing.
+- Confirm buttons compress and pulse while held.
+- Confirm doors animate visually toward open / closed states instead of only switching collision.
+- Confirm hazards pulse to stay readable.
+- Confirm goals pulse while idle and brighten on completion.
+- Run one full playthrough from `MainMenu` to `Level_04_Final` and confirm the new feedback remains readable and not distracting.
+
 ### SC-15 Main Menu And Scene Start Flow
 
 - Open `MainMenu` and confirm the scene contains:


### PR DESCRIPTION
## Update: SC-22 To SC-24 Presentation Batch

### What Changed

- added a runtime `PresentationFeedbackBootstrap` for presentation-layer audio
- added distinct feedback sounds for:
  - jump
  - landing
  - record start
  - record finish
  - replay / clone start
  - button press
  - door open / close
  - hazard hit
  - level completion
  - menu confirm
  - pause toggle
  - restart room
  - level start
- added scene-specific background ambience for:
  - `MainMenu`
  - `Level_01_Tutorial`
  - `Level_02_ButtonDoor`
  - `Level_03_HazardTiming`
  - `Level_04_Final`
- improved player feedback with:
  - smoother state color transitions
  - jump stretch
  - landing squash
- improved interactable readability with:
  - pulsing / compressing buttons
  - animated door open / close visuals
  - pulsing hazards
  - pulsing / brightening goal zones
- updated audio, setup, and smoke-test docs for the presentation pass

### Why It Matters

This moves the project beyond a functional prototype into a more presentable game feel pass. Core interactions are easier to read, transitions feel more intentional, and the campaign has stronger audio identity from scene to scene.

### How It Was Checked

- confirmed runtime audio hooks into gameplay and menu scenes without extra scene wiring
- confirmed each major gameplay interaction now has distinct feedback
- confirmed pause, restart, and level-start transitions now have dedicated cues
- confirmed each scene now has its own ambient background layer
- documented smoke tests for full presentation and readability verification

### Follow-Up Work

- replace generated placeholder audio later if a licensed music / SFX pack is chosen
- continue tuning loudness and feel after repeated playtesting
- finish release QA and packaging on top of this presentation pass
