### PR TITLE
Polish Level 1 onboarding and player physics

### DIFF
--- a/Assets/Scripts/Clone/CloneReplayController.cs
+++ b/Assets/Scripts/Clone/CloneReplayController.cs
@@ -1,4 +1,5 @@
 using System;
+using ShadowClone.Gameplay;
 using UnityEngine;
 
 namespace ShadowClone.Clone
@@ -24,6 +25,7 @@ namespace ShadowClone.Clone
 
             ClearClone();
             activeClone = Instantiate(clonePrefab, clip.Frames[0].Position, Quaternion.identity, cloneParent);
+            IgnorePlayerCollision(activeClone);
             activeClone.ReplayFinished += HandleReplayFinished;
             activeClone.Play(clip.Frames);
             ReplayStarted?.Invoke();
@@ -55,6 +57,43 @@ namespace ShadowClone.Clone
             Destroy(activeClone.gameObject);
             activeClone = null;
             ReplayFinished?.Invoke();
+        }
+
+        private static void IgnorePlayerCollision(CloneActor clone)
+        {
+            if (clone == null)
+            {
+                return;
+            }
+
+            PlayerController player = FindObjectOfType<PlayerController>();
+            if (player == null)
+            {
+                return;
+            }
+
+            Collider2D[] playerColliders = player.GetComponentsInChildren<Collider2D>();
+            Collider2D[] cloneColliders = clone.GetComponentsInChildren<Collider2D>();
+
+            for (int playerIndex = 0; playerIndex < playerColliders.Length; playerIndex++)
+            {
+                Collider2D playerCollider = playerColliders[playerIndex];
+                if (playerCollider == null)
+                {
+                    continue;
+                }
+
+                for (int cloneIndex = 0; cloneIndex < cloneColliders.Length; cloneIndex++)
+                {
+                    Collider2D cloneCollider = cloneColliders[cloneIndex];
+                    if (cloneCollider == null)
+                    {
+                        continue;
+                    }
+
+                    Physics2D.IgnoreCollision(playerCollider, cloneCollider, true);
+                }
+            }
         }
     }
 }

--- a/Assets/Scripts/Gameplay/GroundCheck.cs
+++ b/Assets/Scripts/Gameplay/GroundCheck.cs
@@ -1,3 +1,5 @@
+using ShadowClone.Clone;
+using ShadowClone.Level;
 using UnityEngine;
 
 namespace ShadowClone.Gameplay
@@ -5,29 +7,49 @@ namespace ShadowClone.Gameplay
     public class GroundCheck : MonoBehaviour
     {
         [SerializeField] private Transform checkPoint;
-        [SerializeField] private float checkRadius = 0.15f;
+        [SerializeField] private Vector2 boxSize = new Vector2(0.68f, 0.06f);
+        [SerializeField] private float castDistance = 0.12f;
+        [SerializeField, Range(0f, 1f)] private float minimumGroundNormalY = 0.7f;
         [SerializeField] private LayerMask groundLayers = Physics2D.DefaultRaycastLayers;
 
-        private readonly Collider2D[] overlapResults = new Collider2D[8];
+        private readonly RaycastHit2D[] hitResults = new RaycastHit2D[8];
+        private readonly ContactPoint2D[] contactResults = new ContactPoint2D[16];
+        private Rigidbody2D ownerBody;
 
         public bool IsGrounded
         {
             get
             {
-                Transform target = checkPoint != null ? checkPoint : transform;
-                ContactFilter2D filter = new ContactFilter2D
+                if (HasValidGroundContact())
                 {
-                    useLayerMask = true,
-                    useTriggers = false
-                };
-                filter.SetLayerMask(groundLayers);
+                    return true;
+                }
 
-                int hitCount = Physics2D.OverlapCircle(target.position, checkRadius, filter, overlapResults);
+                Transform target = checkPoint != null ? checkPoint : transform;
+                Vector2 origin = target.position;
+                Vector2 size = new Vector2(Mathf.Max(0.01f, boxSize.x), Mathf.Max(0.01f, boxSize.y));
+                float distance = Mathf.Max(0.01f, castDistance);
+
+                int hitCount = Physics2D.BoxCastNonAlloc(
+                    origin,
+                    size,
+                    0f,
+                    Vector2.down,
+                    hitResults,
+                    distance,
+                    groundLayers);
                 Transform ownerRoot = transform.root;
+
                 for (int i = 0; i < hitCount; i++)
                 {
-                    Collider2D hit = overlapResults[i];
-                    if (hit == null || hit.isTrigger || hit.transform.IsChildOf(ownerRoot))
+                    RaycastHit2D hit = hitResults[i];
+                    Collider2D hitCollider = hit.collider;
+                    if (!IsValidGroundCollider(hitCollider, ownerRoot))
+                    {
+                        continue;
+                    }
+
+                    if (hit.normal.y < minimumGroundNormalY)
                     {
                         continue;
                     }
@@ -39,11 +61,79 @@ namespace ShadowClone.Gameplay
             }
         }
 
+        private void Awake()
+        {
+            ownerBody = GetComponentInParent<Rigidbody2D>();
+        }
+
+        private bool HasValidGroundContact()
+        {
+            if (ownerBody == null)
+            {
+                ownerBody = GetComponentInParent<Rigidbody2D>();
+            }
+
+            if (ownerBody == null)
+            {
+                return false;
+            }
+
+            int contactCount = ownerBody.GetContacts(contactResults);
+            Transform ownerRoot = transform.root;
+
+            for (int i = 0; i < contactCount; i++)
+            {
+                ContactPoint2D contact = contactResults[i];
+                if (!IsValidGroundCollider(contact.collider, ownerRoot))
+                {
+                    continue;
+                }
+
+                if (contact.normal.y >= minimumGroundNormalY)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private bool IsValidGroundCollider(Collider2D hitCollider, Transform ownerRoot)
+        {
+            if (hitCollider == null || hitCollider.isTrigger || hitCollider.transform.IsChildOf(ownerRoot))
+            {
+                return false;
+            }
+
+            int layerMask = 1 << hitCollider.gameObject.layer;
+            if ((groundLayers.value & layerMask) == 0)
+            {
+                return false;
+            }
+
+            if (hitCollider.GetComponentInParent<CloneActor>() != null ||
+                hitCollider.GetComponentInParent<ResetFloor>() != null ||
+                hitCollider.GetComponentInParent<Hazard>() != null ||
+                hitCollider.GetComponentInParent<PuzzleButton>() != null ||
+                hitCollider.GetComponentInParent<DoorController>() != null)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
         private void OnDrawGizmosSelected()
         {
             Transform target = checkPoint != null ? checkPoint : transform;
+            Vector3 origin = target.position;
+            Vector3 size = new Vector3(Mathf.Max(0.01f, boxSize.x), Mathf.Max(0.01f, boxSize.y), 0f);
+            Vector3 castOffset = Vector3.down * Mathf.Max(0.01f, castDistance);
+
             Gizmos.color = Color.yellow;
-            Gizmos.DrawWireSphere(target.position, checkRadius);
+            Gizmos.DrawWireCube(origin, size);
+            Gizmos.color = Color.cyan;
+            Gizmos.DrawWireCube(origin + castOffset, size);
         }
     }
 }

--- a/Assets/Scripts/Gameplay/PlayerController.cs
+++ b/Assets/Scripts/Gameplay/PlayerController.cs
@@ -12,10 +12,14 @@ namespace ShadowClone.Gameplay
         [Header("References")]
         [SerializeField] private GroundCheck groundCheck;
 
+        [Header("Physics")]
+        [SerializeField] private bool applyNoFrictionMaterial = true;
+
         private Rigidbody2D body;
         private float moveInput;
         private bool wasGrounded;
         private bool hasJumpAvailable;
+        private PhysicsMaterial2D noFrictionMaterial;
 
         public bool IsGrounded => groundCheck != null && groundCheck.IsGrounded;
         public bool IsMovementLocked { get; private set; }
@@ -27,6 +31,7 @@ namespace ShadowClone.Gameplay
         private void Awake()
         {
             body = GetComponent<Rigidbody2D>();
+            ApplyNoFrictionMaterial();
         }
 
         private void Start()
@@ -98,6 +103,32 @@ namespace ShadowClone.Gameplay
             {
                 moveInput = 0f;
                 body.velocity = new Vector2(0f, body.velocity.y);
+            }
+        }
+
+        private void ApplyNoFrictionMaterial()
+        {
+            if (!applyNoFrictionMaterial)
+            {
+                return;
+            }
+
+            noFrictionMaterial = new PhysicsMaterial2D("Player_NoFriction_Runtime")
+            {
+                friction = 0f,
+                bounciness = 0f
+            };
+
+            Collider2D[] colliders = GetComponentsInChildren<Collider2D>();
+            for (int i = 0; i < colliders.Length; i++)
+            {
+                Collider2D playerCollider = colliders[i];
+                if (playerCollider == null || playerCollider.isTrigger)
+                {
+                    continue;
+                }
+
+                playerCollider.sharedMaterial = noFrictionMaterial;
             }
         }
     }

--- a/Assets/Scripts/Level/LevelOneOnboardingBootstrap.cs
+++ b/Assets/Scripts/Level/LevelOneOnboardingBootstrap.cs
@@ -1,4 +1,7 @@
 using ShadowClone.Core;
+using ShadowClone.Gameplay;
+using ShadowClone.UI;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -7,17 +10,36 @@ namespace ShadowClone.Level
     public class LevelOneOnboardingBootstrap : MonoBehaviour
     {
         private const string BootstrapObjectName = "LevelOneOnboardingBootstrap";
+        private const float DoorTutorialCompleteX = 56f;
+        private const float DefaultPromptDuration = 3.2f;
+        private const float PersistentPromptDuration = 999f;
+        private const string MovementPrompt = "A = MOVE LEFT | D = MOVE RIGHT\nSPACE = JUMP\n<size=70%>ESC = PAUSE</size>";
+        private const string ClonePrompt = "R = RECORD SHADOW | E = REPLAY SHADOW\nSHADOW REPLAY LASTS 3 SECONDS";
         private static LevelOneOnboardingBootstrap instance;
+        private static bool hasCompletedGapTutorial;
+        private static bool hasCompletedDoorTutorial;
+        private static bool hasCompletedExitTutorial;
 
         private static readonly PromptPlacement[] PromptPlacements =
         {
-            new PromptPlacement("A = MOVE LEFT | D = MOVE RIGHT\nSPACE = JUMP", 0f),
-            new PromptPlacement("JUMP OVER PLATFORMS", 0.06f),
-            new PromptPlacement("R = RECORD SHADOW | E = REPLAY SHADOW\nSHADOW REPLAY LASTS 3 SECONDS", 0.16f),
-            new PromptPlacement("CLONE CAN HOLD BUTTONS", 0.215f),
-            new PromptPlacement("USE CLONE TO OPEN THE DOOR", 0.24f),
-            new PromptPlacement("REACH THE EXIT", 0.9f)
+            new PromptPlacement(MovementPrompt, 0f, TutorialProgressSection.None, TutorialProgressAction.Show, true, PersistentPromptDuration),
+            new PromptPlacement("JUMP OVER GAPS", 0.06f, TutorialProgressSection.Gap, TutorialProgressAction.Show),
+            new PromptPlacement(string.Empty, 0.12f, TutorialProgressSection.Gap, TutorialProgressAction.Complete),
+            new PromptPlacement(ClonePrompt, 0.16f, TutorialProgressSection.None, TutorialProgressAction.Show, true, PersistentPromptDuration),
+            new PromptPlacement("CLONE CAN HOLD BUTTONS\nUSE IT TO OPEN THE DOOR", 0.215f, TutorialProgressSection.Door, TutorialProgressAction.Show, false, PersistentPromptDuration),
+            new PromptPlacement("REACH THE EXIT", 0.9f, TutorialProgressSection.Exit, TutorialProgressAction.Show)
         };
+
+        private GoalZone trackedGoalZone;
+        private RoomResetManager trackedResetManager;
+        private PlayerController trackedPlayer;
+        private readonly List<OnboardingPromptTrigger> replayAfterResetTriggers = new List<OnboardingPromptTrigger>();
+        private bool hasPressedMoveRight;
+        private bool hasPressedJump;
+        private bool hasCompletedMovementPrompt;
+        private bool hasPressedRecord;
+        private bool hasPressedReplay;
+        private bool hasCompletedClonePrompt;
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         private static void Bootstrap()
@@ -45,8 +67,57 @@ namespace ShadowClone.Level
             HandleSceneLoaded(SceneManager.GetActiveScene(), LoadSceneMode.Single);
         }
 
+        private void Update()
+        {
+            TrackActionPromptCompletion();
+
+            if (trackedPlayer == null || hasCompletedDoorTutorial)
+            {
+                return;
+            }
+
+            if (trackedPlayer.transform.position.x >= DoorTutorialCompleteX)
+            {
+                CompleteProgressSection(TutorialProgressSection.Door);
+            }
+        }
+
+        private void TrackActionPromptCompletion()
+        {
+            if (SceneManager.GetActiveScene().name != SceneRegistry.Tutorial)
+            {
+                return;
+            }
+
+            if (!hasCompletedMovementPrompt)
+            {
+                hasPressedMoveRight |= Input.GetKeyDown(KeyCode.D);
+                hasPressedJump |= Input.GetKeyDown(KeyCode.Space) || Input.GetButtonDown("Jump");
+
+                if (hasPressedMoveRight && hasPressedJump)
+                {
+                    hasCompletedMovementPrompt = true;
+                    GameplayUiBootstrap.HideOnboardingPrompt(MovementPrompt);
+                }
+            }
+
+            if (!hasCompletedClonePrompt)
+            {
+                hasPressedRecord |= Input.GetKeyDown(KeyCode.R);
+                hasPressedReplay |= Input.GetKeyDown(KeyCode.E);
+
+                if (hasPressedRecord && hasPressedReplay)
+                {
+                    hasCompletedClonePrompt = true;
+                    GameplayUiBootstrap.HideOnboardingPrompt(ClonePrompt);
+                }
+            }
+        }
+
         private void OnDestroy()
         {
+            ReleaseLevelOneSubscriptions();
+
             if (instance == this)
             {
                 SceneManager.sceneLoaded -= HandleSceneLoaded;
@@ -56,10 +127,15 @@ namespace ShadowClone.Level
 
         private void HandleSceneLoaded(Scene scene, LoadSceneMode mode)
         {
+            ReleaseLevelOneSubscriptions();
+
             if (scene.name != SceneRegistry.Tutorial)
             {
                 return;
             }
+
+            ResetRuntimeProgress();
+            ResetActionPromptProgress();
 
             SpawnPoint spawnPoint = FindObjectOfType<SpawnPoint>();
             GoalZone goalZone = FindObjectOfType<GoalZone>();
@@ -79,13 +155,27 @@ namespace ShadowClone.Level
             {
                 PromptPlacement placement = PromptPlacements[i];
                 float x = startX + length * placement.NormalizedX;
-                CreatePromptTrigger(root.transform, i + 1, placement.Message, new Vector2(x, -1.2f));
+                CreatePromptTrigger(root.transform, i + 1, placement, new Vector2(x, -1.2f));
             }
+
+            trackedPlayer = FindObjectOfType<PlayerController>();
+            trackedResetManager = FindObjectOfType<RoomResetManager>();
+            if (trackedResetManager != null)
+            {
+                trackedResetManager.ResetCompleted += HandleResetCompleted;
+            }
+
+            trackedGoalZone = goalZone;
+            trackedGoalZone.Completed += HandleGoalCompleted;
         }
 
-        private static void CreatePromptTrigger(Transform parent, int index, string prompt, Vector2 position)
+        private static void CreatePromptTrigger(Transform parent, int index, PromptPlacement placement, Vector2 position)
         {
-            string safePromptName = prompt
+            string label = string.IsNullOrWhiteSpace(placement.Message)
+                ? $"{placement.Section}_{placement.Action}"
+                : placement.Message;
+
+            string safePromptName = label
                 .Replace('\n', '_')
                 .Replace(' ', '_')
                 .Replace('/', '_')
@@ -100,19 +190,153 @@ namespace ShadowClone.Level
             trigger.size = new Vector2(8f, 8f);
 
             OnboardingPromptTrigger promptTrigger = triggerObject.AddComponent<OnboardingPromptTrigger>();
-            promptTrigger.Configure(prompt, 3.2f);
+            promptTrigger.Configure(placement.Message, placement.Duration, placement.Section, placement.Action, placement.ReplayAfterReset);
+
+            if (placement.ReplayAfterReset && instance != null)
+            {
+                instance.replayAfterResetTriggers.Add(promptTrigger);
+            }
+        }
+
+        internal static bool TryShowProgressPrompt(TutorialProgressSection section, string message, float duration)
+        {
+            if (IsSectionCompleted(section))
+            {
+                return false;
+            }
+
+            GameplayUiBootstrap.ShowOnboardingPrompt(message, duration);
+            return true;
+        }
+
+        internal static void CompleteProgressSection(TutorialProgressSection section)
+        {
+            if (IsSectionCompleted(section))
+            {
+                return;
+            }
+
+            switch (section)
+            {
+                case TutorialProgressSection.Gap:
+                    hasCompletedGapTutorial = true;
+                    break;
+                case TutorialProgressSection.Door:
+                    hasCompletedDoorTutorial = true;
+                    break;
+                case TutorialProgressSection.Exit:
+                    hasCompletedExitTutorial = true;
+                    break;
+            }
+
+            GameplayUiBootstrap.HideOnboardingPrompt();
+        }
+
+        private static bool IsSectionCompleted(TutorialProgressSection section)
+        {
+            return section switch
+            {
+                TutorialProgressSection.Gap => hasCompletedGapTutorial,
+                TutorialProgressSection.Door => hasCompletedDoorTutorial,
+                TutorialProgressSection.Exit => hasCompletedExitTutorial,
+                _ => false
+            };
+        }
+
+        private static void ResetRuntimeProgress()
+        {
+            hasCompletedGapTutorial = false;
+            hasCompletedDoorTutorial = false;
+            hasCompletedExitTutorial = false;
+        }
+
+        private void ResetActionPromptProgress()
+        {
+            hasPressedMoveRight = false;
+            hasPressedJump = false;
+            hasCompletedMovementPrompt = false;
+            hasPressedRecord = false;
+            hasPressedReplay = false;
+            hasCompletedClonePrompt = false;
+        }
+
+        private void HandleResetCompleted(string reason)
+        {
+            GameplayUiBootstrap.HideOnboardingPrompt();
+            ResetActionPromptProgress();
+
+            for (int i = 0; i < replayAfterResetTriggers.Count; i++)
+            {
+                if (replayAfterResetTriggers[i] != null)
+                {
+                    replayAfterResetTriggers[i].ResetForAttempt();
+                }
+            }
+
+            GameplayUiBootstrap.ShowOnboardingPrompt(MovementPrompt, PersistentPromptDuration);
+        }
+
+        private void HandleGoalCompleted()
+        {
+            CompleteProgressSection(TutorialProgressSection.Exit);
+        }
+
+        private void ReleaseLevelOneSubscriptions()
+        {
+            if (trackedGoalZone != null)
+            {
+                trackedGoalZone.Completed -= HandleGoalCompleted;
+                trackedGoalZone = null;
+            }
+
+            if (trackedResetManager != null)
+            {
+                trackedResetManager.ResetCompleted -= HandleResetCompleted;
+                trackedResetManager = null;
+            }
+
+            trackedPlayer = null;
+            replayAfterResetTriggers.Clear();
         }
 
         private readonly struct PromptPlacement
         {
-            public PromptPlacement(string message, float normalizedX)
+            public PromptPlacement(
+                string message,
+                float normalizedX,
+                TutorialProgressSection section,
+                TutorialProgressAction action,
+                bool replayAfterReset = false,
+                float duration = DefaultPromptDuration)
             {
                 Message = message;
                 NormalizedX = normalizedX;
+                Section = section;
+                Action = action;
+                ReplayAfterReset = replayAfterReset;
+                Duration = duration;
             }
 
             public string Message { get; }
             public float NormalizedX { get; }
+            public TutorialProgressSection Section { get; }
+            public TutorialProgressAction Action { get; }
+            public bool ReplayAfterReset { get; }
+            public float Duration { get; }
         }
+    }
+
+    public enum TutorialProgressSection
+    {
+        None,
+        Gap,
+        Door,
+        Exit
+    }
+
+    public enum TutorialProgressAction
+    {
+        Show,
+        Complete
     }
 }

--- a/Assets/Scripts/Level/OnboardingPromptTrigger.cs
+++ b/Assets/Scripts/Level/OnboardingPromptTrigger.cs
@@ -9,6 +9,9 @@ namespace ShadowClone.Level
     {
         [SerializeField] private string message;
         [SerializeField] private float duration = 3.2f;
+        [SerializeField] private TutorialProgressSection progressSection;
+        [SerializeField] private TutorialProgressAction progressAction;
+        [SerializeField] private bool replayAfterReset;
 
         private bool hasTriggered;
 
@@ -20,7 +23,24 @@ namespace ShadowClone.Level
 
         private void OnTriggerEnter2D(Collider2D other)
         {
-            if (hasTriggered || other.GetComponentInParent<PlayerController>() == null)
+            if (other.GetComponentInParent<PlayerController>() == null)
+            {
+                return;
+            }
+
+            if (progressSection != TutorialProgressSection.None)
+            {
+                if (progressAction == TutorialProgressAction.Complete)
+                {
+                    LevelOneOnboardingBootstrap.CompleteProgressSection(progressSection);
+                    return;
+                }
+
+                LevelOneOnboardingBootstrap.TryShowProgressPrompt(progressSection, message, duration);
+                return;
+            }
+
+            if (hasTriggered)
             {
                 return;
             }
@@ -33,6 +53,28 @@ namespace ShadowClone.Level
         {
             message = prompt;
             duration = promptDuration;
+        }
+
+        public void Configure(
+            string prompt,
+            float promptDuration,
+            TutorialProgressSection section,
+            TutorialProgressAction action,
+            bool shouldReplayAfterReset = false)
+        {
+            message = prompt;
+            duration = promptDuration;
+            progressSection = section;
+            progressAction = action;
+            replayAfterReset = shouldReplayAfterReset;
+        }
+
+        public void ResetForAttempt()
+        {
+            if (replayAfterReset)
+            {
+                hasTriggered = false;
+            }
         }
     }
 }

--- a/Assets/Scripts/UI/GameplayUiBootstrap.cs
+++ b/Assets/Scripts/UI/GameplayUiBootstrap.cs
@@ -55,10 +55,21 @@ namespace ShadowClone.UI
         private float successOverlayTimer;
         private float onboardingTimer;
         private float starBindRetryTimer;
+        private string currentOnboardingMessage;
 
         public static void ShowOnboardingPrompt(string message, float duration = 3.2f)
         {
             instance?.ShowOnboarding(message, duration);
+        }
+
+        public static void HideOnboardingPrompt()
+        {
+            instance?.HideOnboarding();
+        }
+
+        public static void HideOnboardingPrompt(string message)
+        {
+            instance?.HideOnboarding(message);
         }
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
@@ -239,8 +250,9 @@ namespace ShadowClone.UI
             onboardingRect.anchorMax = new Vector2(0.5f, 1f);
             onboardingRect.pivot = new Vector2(0.5f, 1f);
             onboardingRect.anchoredPosition = new Vector2(0f, -80f);
-            onboardingRect.sizeDelta = new Vector2(760f, 72f);
+            onboardingRect.sizeDelta = new Vector2(760f, 104f);
             onboardingLabel = CreateText("OnboardingLabel", onboardingPanel.transform, 28, TextAlignmentOptions.Center, string.Empty, TypographyRole.Hud);
+            onboardingLabel.richText = true;
             RectTransform onboardingLabelRect = onboardingLabel.rectTransform;
             onboardingLabelRect.anchorMin = Vector2.zero;
             onboardingLabelRect.anchorMax = Vector2.one;
@@ -264,6 +276,7 @@ namespace ShadowClone.UI
             completionTitle = CreateText("CompletionTitle", completionPanel.transform, 42, TextAlignmentOptions.Center, "COMPLETE", TypographyRole.Title);
             completionBody = CreateText("CompletionBody", completionPanel.transform, 24, TextAlignmentOptions.Center,
                 "ROOM CLEAR", TypographyRole.Hud);
+            ConfigureCompletionTextLayout();
 
             nextLevelButton = CreateButton("NextLevelButton", completionPanel.transform, "NEXT", new Vector2(0f, -12f), LoadNextLevel);
             CreateButton("ReplayLevelButton", completionPanel.transform, "REPLAY", new Vector2(0f, -72f), RestartRoom);
@@ -462,12 +475,14 @@ namespace ShadowClone.UI
             if (hasNextLevel)
             {
                 completionTitle.text = "COMPLETE";
+                completionTitle.fontSize = 42;
                 completionBody.text = GetCompletionBodyText("ROOM CLEAR");
                 nextLevelButton.gameObject.SetActive(true);
             }
             else
             {
-                completionTitle.text = "PROTOTYPE COMPLETE";
+                completionTitle.text = "DEMO\nCOMPLETE";
+                completionTitle.fontSize = 38;
                 completionBody.text = GetCompletionBodyText("SIMULATION CLEAR");
                 nextLevelButton.gameObject.SetActive(false);
             }
@@ -564,6 +579,26 @@ namespace ShadowClone.UI
             textRect.sizeDelta = Vector2.zero;
 
             return button;
+        }
+
+        private void ConfigureCompletionTextLayout()
+        {
+            if (completionTitle != null)
+            {
+                RectTransform titleRect = completionTitle.rectTransform;
+                titleRect.anchoredPosition = new Vector2(0f, -24f);
+                titleRect.sizeDelta = new Vector2(640f, 92f);
+                completionTitle.lineSpacing = -16f;
+            }
+
+            if (completionBody != null)
+            {
+                RectTransform bodyRect = completionBody.rectTransform;
+                bodyRect.anchoredPosition = new Vector2(0f, -132f);
+                bodyRect.sizeDelta = new Vector2(640f, 48f);
+                completionBody.fontSize = 20f;
+                completionBody.lineSpacing = -10f;
+            }
         }
 
         private void RebindSceneDependencies()
@@ -782,9 +817,31 @@ namespace ShadowClone.UI
             }
 
             onboardingLabel.text = TypographyTheme.NormalizeToken(message);
+            currentOnboardingMessage = message;
             onboardingTimer = Mathf.Max(0.5f, duration);
             onboardingPanel.SetActive(true);
             UpdateOnboardingPrompt();
+        }
+
+        private void HideOnboarding()
+        {
+            onboardingTimer = 0f;
+            currentOnboardingMessage = null;
+
+            if (onboardingPanel != null)
+            {
+                onboardingPanel.SetActive(false);
+            }
+        }
+
+        private void HideOnboarding(string message)
+        {
+            if (!string.Equals(currentOnboardingMessage, message, System.StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            HideOnboarding();
         }
 
         private void UpdateOnboardingPrompt()


### PR DESCRIPTION
## Summary
- Updated Level 1 onboarding so key prompts behave correctly across resets.
- Added persistent/action-aware prompts for movement, jump, record, replay, and ESC pause.
- Made the door tutorial hide after the player passes the intended X position.
- Fixed completion UI spacing so text no longer overlaps buttons.
- Improved grounded detection to reject platform side contacts.
- Added player no-friction physics material to reduce wall/edge sticking.
- Disabled only Player ↔ Clone physical collision while keeping clone button/trigger interactions active.

## Validation
- `dotnet build ShadowClone.sln` passes with 0 errors.
- Needs Unity Play Mode verification for tutorial prompt timing, side-contact jumping, clone button interaction, and completion panel layout.

## Changed Files
- `Assets/Scripts/Clone/CloneReplayController.cs`
- `Assets/Scripts/Gameplay/GroundCheck.cs`
- `Assets/Scripts/Gameplay/PlayerController.cs`
- `Assets/Scripts/Level/LevelOneOnboardingBootstrap.cs`
- `Assets/Scripts/Level/OnboardingPromptTrigger.cs`
- `Assets/Scripts/UI/GameplayUiBootstrap.cs`
