### PR TITLE
Restore player and clone physics interaction

### DIFF
--- a/Assets/Scripts/Clone/CloneReplayController.cs
+++ b/Assets/Scripts/Clone/CloneReplayController.cs
@@ -1,5 +1,4 @@
 using System;
-using ShadowClone.Gameplay;
 using UnityEngine;
 
 namespace ShadowClone.Clone
@@ -25,7 +24,6 @@ namespace ShadowClone.Clone
 
             ClearClone();
             activeClone = Instantiate(clonePrefab, clip.Frames[0].Position, Quaternion.identity, cloneParent);
-            IgnorePlayerCollision(activeClone);
             activeClone.ReplayFinished += HandleReplayFinished;
             activeClone.Play(clip.Frames);
             ReplayStarted?.Invoke();
@@ -57,43 +55,6 @@ namespace ShadowClone.Clone
             Destroy(activeClone.gameObject);
             activeClone = null;
             ReplayFinished?.Invoke();
-        }
-
-        private static void IgnorePlayerCollision(CloneActor clone)
-        {
-            if (clone == null)
-            {
-                return;
-            }
-
-            PlayerController player = FindObjectOfType<PlayerController>();
-            if (player == null)
-            {
-                return;
-            }
-
-            Collider2D[] playerColliders = player.GetComponentsInChildren<Collider2D>();
-            Collider2D[] cloneColliders = clone.GetComponentsInChildren<Collider2D>();
-
-            for (int playerIndex = 0; playerIndex < playerColliders.Length; playerIndex++)
-            {
-                Collider2D playerCollider = playerColliders[playerIndex];
-                if (playerCollider == null)
-                {
-                    continue;
-                }
-
-                for (int cloneIndex = 0; cloneIndex < cloneColliders.Length; cloneIndex++)
-                {
-                    Collider2D cloneCollider = cloneColliders[cloneIndex];
-                    if (cloneCollider == null)
-                    {
-                        continue;
-                    }
-
-                    Physics2D.IgnoreCollision(playerCollider, cloneCollider, true);
-                }
-            }
         }
     }
 }

--- a/Assets/Scripts/Gameplay/GroundCheck.cs
+++ b/Assets/Scripts/Gameplay/GroundCheck.cs
@@ -1,4 +1,3 @@
-using ShadowClone.Clone;
 using ShadowClone.Level;
 using UnityEngine;
 
@@ -111,8 +110,7 @@ namespace ShadowClone.Gameplay
                 return false;
             }
 
-            if (hitCollider.GetComponentInParent<CloneActor>() != null ||
-                hitCollider.GetComponentInParent<ResetFloor>() != null ||
+            if (hitCollider.GetComponentInParent<ResetFloor>() != null ||
                 hitCollider.GetComponentInParent<Hazard>() != null ||
                 hitCollider.GetComponentInParent<PuzzleButton>() != null ||
                 hitCollider.GetComponentInParent<DoorController>() != null)


### PR DESCRIPTION
## Summary
- Restored physical interaction between the player and replay clone.
- Removed the Player ↔ Clone collision ignore behavior.
- Allowed the clone to be treated as valid ground again when the player lands on it from above.
- Kept the side-sticking/ground-normal safety logic intact.

## Validation
- `dotnet build ShadowClone.sln` passes with 0 errors.
- Branch is able to merge cleanly.

## Notes
- This PR focuses only on restoring clone/player interaction.
- Clone should still trigger buttons and puzzle logic as before.
- Please verify in Unity Play Mode that the player can jump/use the clone again.
